### PR TITLE
Implement Ed25519 signature verification

### DIFF
--- a/spike2/src/CryptoTests.java
+++ b/spike2/src/CryptoTests.java
@@ -1,6 +1,8 @@
 import berryssh.crypto.ChaCha20;
 import berryssh.crypto.Poly1305;
+import berryssh.crypto.Ed25519;
 import berryssh.crypto.SHA256;
+import berryssh.crypto.SHA512;
 import berryssh.crypto.X25519;
 
 /**
@@ -21,6 +23,8 @@ public class CryptoTests {
         poly1305Vector();
         aeadVector();
         x25519Vectors();
+        sha512Vectors();
+        ed25519Vectors();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -175,6 +179,88 @@ public class CryptoTests {
         } else {
             failed++;
             System.out.println("  FAIL  X25519 all-zero shared secret detected");
+        }
+    }
+
+    private static void sha512Vectors() {
+        check("SHA-512 empty", SHA512.hash(new byte[0]),
+            "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce"
+          + "47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
+        check("SHA-512 abc", SHA512.hash(ascii("abc")),
+            "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a"
+          + "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f");
+        // Crosses the 112-byte padding boundary, where the length field forces
+        // an extra block.
+        check("SHA-512 two-block", SHA512.hash(ascii(
+                "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+              + "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")),
+            "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018"
+          + "501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909");
+    }
+
+    /** RFC 8032 section 7.1. */
+    private static void ed25519Vectors() {
+        // TEST 1: empty message.
+        boolean ok = Ed25519.verify(
+            hex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"),
+            new byte[0],
+            hex("e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e06522490155"
+              + "5fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b"));
+        report("Ed25519 RFC 8032 TEST 1 (empty message)", ok);
+
+        // TEST 2: one-byte message.
+        ok = Ed25519.verify(
+            hex("3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c"),
+            hex("72"),
+            hex("92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da"
+              + "085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00"));
+        report("Ed25519 RFC 8032 TEST 2 (1-byte message)", ok);
+
+        // TEST 3: two-byte message.
+        ok = Ed25519.verify(
+            hex("fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025"),
+            hex("af82"),
+            hex("6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac"
+              + "18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a"));
+        report("Ed25519 RFC 8032 TEST 3 (2-byte message)", ok);
+
+        // A verifier that ignores its inputs passes every positive vector, so
+        // the negative cases are the ones that actually test anything.
+        byte[] pk = hex("3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c");
+        byte[] sig = hex("92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da"
+                       + "085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00");
+
+        byte[] flipped = new byte[64];
+        System.arraycopy(sig, 0, flipped, 0, 64);
+        flipped[10] ^= 0x01;
+        report("Ed25519 rejects a flipped signature bit",
+            !Ed25519.verify(pk, hex("72"), flipped));
+
+        report("Ed25519 rejects a modified message",
+            !Ed25519.verify(pk, hex("73"), sig));
+
+        byte[] wrongKey = hex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a");
+        report("Ed25519 rejects the wrong public key",
+            !Ed25519.verify(wrongKey, hex("72"), sig));
+
+        // S must be below the group order, or a signature can be reshaped.
+        byte[] highS = new byte[64];
+        System.arraycopy(sig, 0, highS, 0, 64);
+        for (int i = 32; i < 64; i++) {
+            highS[i] = (byte) 0xff;
+        }
+        report("Ed25519 rejects S >= L", !Ed25519.verify(pk, hex("72"), highS));
+
+        report("Ed25519 rejects a malformed length", !Ed25519.verify(pk, hex("72"), hex("00")));
+    }
+
+    private static void report(String name, boolean ok) {
+        if (ok) {
+            passed++;
+            System.out.println("  PASS  " + name);
+        } else {
+            failed++;
+            System.out.println("  FAIL  " + name);
         }
     }
 

--- a/ssh/src/berryssh/crypto/Ed25519.java
+++ b/ssh/src/berryssh/crypto/Ed25519.java
@@ -1,0 +1,378 @@
+package berryssh.crypto;
+
+/**
+ * RFC 8032 Ed25519 signature verification, for {@code ssh-ed25519} host keys.
+ *
+ * Verification only. Nothing here handles a private key, so there is no secret
+ * to leak and the scalar multiplication is a plain double-and-add over public
+ * data.
+ *
+ * The curve constants are derived at class-load rather than written out as hex,
+ * which removes transcription error as a failure mode: {@code d} comes from
+ * -121665/121666 and {@code sqrt(-1)} from an exponentiation, both computed
+ * with {@link Fe25519}. The cost is a handful of field inversions, once.
+ *
+ * Written for -source 1.3.
+ */
+public final class Ed25519 {
+
+    public static final int PUBLIC_KEY_LENGTH = 32;
+    public static final int SIGNATURE_LENGTH = 64;
+
+    /** Curve constant d = -121665/121666, and 2d as used by the addition formula. */
+    private static final int[] D = Fe25519.create();
+    private static final int[] D2 = Fe25519.create();
+    /** A square root of -1, needed when decompressing a point. */
+    private static final int[] SQRT_M1 = Fe25519.create();
+    /** The base point B. */
+    private static final Point BASE;
+
+    /**
+     * The group order L = 2^252 + 27742317777372353535851937790883648493, little
+     * endian. `verify` rejects any S >= L, which is what stops a valid
+     * signature from being trivially reshaped into another valid one.
+     */
+    private static final int[] L = {
+        0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
+        0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10
+    };
+
+    static {
+        int[] num = Fe25519.create();
+        int[] den = Fe25519.create();
+        num[0] = 121665;
+        den[0] = 121666;
+        int[] negNum = Fe25519.create();
+        Fe25519.sub(negNum, Fe25519.create(), num);   // -121665
+        int[] invDen = Fe25519.create();
+        Fe25519.invert(invDen, den);
+        Fe25519.mul(D, negNum, invDen);
+        Fe25519.add(D2, D, D);
+        Fe25519.reduce(D2);
+
+        // sqrt(-1) = 2^((p-1)/4), and (p-1)/4 = 2*((p-5)/8) + 1, so it follows
+        // from the same exponentiation decompression already needs.
+        int[] two = Fe25519.create();
+        two[0] = 2;
+        int[] t = Fe25519.create();
+        pow2523(t, two);
+        Fe25519.sq(t, t);
+        Fe25519.mul(SQRT_M1, t, two);
+
+        // B has y = 4/5 and the even x.
+        int[] four = Fe25519.create();
+        int[] five = Fe25519.create();
+        four[0] = 4;
+        five[0] = 5;
+        int[] invFive = Fe25519.create();
+        Fe25519.invert(invFive, five);
+        int[] by = Fe25519.create();
+        Fe25519.mul(by, four, invFive);
+        byte[] encoded = new byte[32];
+        Fe25519.toBytes(encoded, 0, by);
+        BASE = decompress(encoded, 0);
+        if (BASE == null) {
+            throw new IllegalStateException("base point failed to decompress");
+        }
+    }
+
+    private Ed25519() {
+    }
+
+    /** A point in extended coordinates: x = X/Z, y = Y/Z, xy = T/Z. */
+    private static final class Point {
+        final int[] x = Fe25519.create();
+        final int[] y = Fe25519.create();
+        final int[] z = Fe25519.create();
+        final int[] t = Fe25519.create();
+    }
+
+    private static Point identity() {
+        Point p = new Point();
+        p.y[0] = 1;
+        p.z[0] = 1;
+        return p;
+    }
+
+    private static Point copyOf(Point p) {
+        Point q = new Point();
+        Fe25519.copy(q.x, p.x);
+        Fe25519.copy(q.y, p.y);
+        Fe25519.copy(q.z, p.z);
+        Fe25519.copy(q.t, p.t);
+        return q;
+    }
+
+    /** Unified addition for a = -1 twisted Edwards curves. */
+    private static void add(Point r, Point p, Point q) {
+        int[] a = Fe25519.create(), b = Fe25519.create(), c = Fe25519.create();
+        int[] d = Fe25519.create(), e = Fe25519.create(), f = Fe25519.create();
+        int[] g = Fe25519.create(), h = Fe25519.create(), tmp = Fe25519.create();
+
+        Fe25519.sub(a, p.y, p.x);
+        Fe25519.sub(tmp, q.y, q.x);
+        Fe25519.mul(a, a, tmp);
+
+        Fe25519.add(b, p.y, p.x);
+        Fe25519.add(tmp, q.y, q.x);
+        Fe25519.mul(b, b, tmp);
+
+        Fe25519.mul(c, p.t, q.t);
+        Fe25519.mul(c, c, D2);
+
+        Fe25519.mul(d, p.z, q.z);
+        Fe25519.add(d, d, d);
+
+        Fe25519.sub(e, b, a);
+        Fe25519.sub(f, d, c);
+        Fe25519.add(g, d, c);
+        Fe25519.add(h, b, a);
+
+        // These are sums of sums; mul needs them back inside its input bounds.
+        Fe25519.reduce(e);
+        Fe25519.reduce(f);
+        Fe25519.reduce(g);
+        Fe25519.reduce(h);
+
+        Fe25519.mul(r.x, e, f);
+        Fe25519.mul(r.y, g, h);
+        Fe25519.mul(r.t, e, h);
+        Fe25519.mul(r.z, f, g);
+    }
+
+    private static void dbl(Point r, Point p) {
+        int[] a = Fe25519.create(), b = Fe25519.create(), c = Fe25519.create();
+        int[] e = Fe25519.create(), f = Fe25519.create(), g = Fe25519.create();
+        int[] h = Fe25519.create(), tmp = Fe25519.create();
+
+        Fe25519.sq(a, p.x);
+        Fe25519.sq(b, p.y);
+        Fe25519.sq(c, p.z);
+        Fe25519.add(c, c, c);
+
+        Fe25519.add(h, a, b);
+        Fe25519.add(tmp, p.x, p.y);
+        Fe25519.sq(tmp, tmp);
+        Fe25519.sub(e, h, tmp);
+        Fe25519.sub(g, a, b);
+        Fe25519.add(f, c, g);
+
+        // f reaches ~2^27 here (2*Z^2 plus A-B), which is past what mul takes.
+        Fe25519.reduce(e);
+        Fe25519.reduce(f);
+        Fe25519.reduce(g);
+        Fe25519.reduce(h);
+
+        Fe25519.mul(r.x, e, f);
+        Fe25519.mul(r.y, g, h);
+        Fe25519.mul(r.t, e, h);
+        Fe25519.mul(r.z, f, g);
+    }
+
+    private static void negate(Point r, Point p) {
+        Fe25519.sub(r.x, Fe25519.create(), p.x);
+        Fe25519.copy(r.y, p.y);
+        Fe25519.copy(r.z, p.z);
+        Fe25519.sub(r.t, Fe25519.create(), p.t);
+    }
+
+    /**
+     * Double-and-add over the bits of a little-endian scalar. Not constant
+     * time, which is fine: every input here is public.
+     */
+    private static Point scalarMult(Point p, byte[] scalar, int bits) {
+        Point r = identity();
+        Point base = copyOf(p);
+        Point tmp = new Point();
+        for (int i = bits - 1; i >= 0; i--) {
+            dbl(tmp, r);
+            Point t = r; r = tmp; tmp = t;
+            if (((scalar[i >>> 3] >>> (i & 7)) & 1) != 0) {
+                add(tmp, r, base);
+                t = r; r = tmp; tmp = t;
+            }
+        }
+        return r;
+    }
+
+    /** z^((p-5)/8), the exponentiation point decompression needs. */
+    private static void pow2523(int[] out, int[] z) {
+        int[] t0 = Fe25519.create(), t1 = Fe25519.create(), t2 = Fe25519.create();
+        int i;
+
+        Fe25519.sq(t0, z);
+        Fe25519.sq(t1, t0); Fe25519.sq(t1, t1);
+        Fe25519.mul(t1, z, t1);
+        Fe25519.mul(t0, t0, t1);
+        Fe25519.sq(t0, t0);
+        Fe25519.mul(t0, t1, t0);
+
+        Fe25519.sq(t1, t0);
+        for (i = 1; i < 5; i++) { Fe25519.sq(t1, t1); }
+        Fe25519.mul(t0, t1, t0);
+
+        Fe25519.sq(t1, t0);
+        for (i = 1; i < 10; i++) { Fe25519.sq(t1, t1); }
+        Fe25519.mul(t1, t1, t0);
+
+        Fe25519.sq(t2, t1);
+        for (i = 1; i < 20; i++) { Fe25519.sq(t2, t2); }
+        Fe25519.mul(t1, t2, t1);
+
+        Fe25519.sq(t1, t1);
+        for (i = 1; i < 10; i++) { Fe25519.sq(t1, t1); }
+        Fe25519.mul(t0, t1, t0);
+
+        Fe25519.sq(t1, t0);
+        for (i = 1; i < 50; i++) { Fe25519.sq(t1, t1); }
+        Fe25519.mul(t1, t1, t0);
+
+        Fe25519.sq(t2, t1);
+        for (i = 1; i < 100; i++) { Fe25519.sq(t2, t2); }
+        Fe25519.mul(t1, t2, t1);
+
+        Fe25519.sq(t1, t1);
+        for (i = 1; i < 50; i++) { Fe25519.sq(t1, t1); }
+        Fe25519.mul(t0, t1, t0);
+
+        Fe25519.sq(t0, t0);
+        Fe25519.sq(t0, t0);
+        Fe25519.mul(out, t0, z);
+    }
+
+    /** Recovers a point from its 32-byte encoding, or null if it is not on the curve. */
+    private static Point decompress(byte[] s, int off) {
+        Point p = new Point();
+        int[] u = Fe25519.create(), v = Fe25519.create();
+        int[] v3 = Fe25519.create(), vxx = Fe25519.create(), check = Fe25519.create();
+
+        Fe25519.fromBytes(p.y, s, off);
+        p.z[0] = 1;
+
+        Fe25519.sq(u, p.y);
+        Fe25519.mul(v, u, D);
+        Fe25519.sub(u, u, p.z);      // y^2 - 1
+        Fe25519.add(v, v, p.z);      // d*y^2 + 1
+
+        Fe25519.sq(v3, v);
+        Fe25519.mul(v3, v3, v);      // v^3
+        Fe25519.sq(p.x, v3);
+        Fe25519.mul(p.x, p.x, v);
+        Fe25519.mul(p.x, p.x, u);    // u * v^7
+
+        pow2523(p.x, p.x);
+        Fe25519.mul(p.x, p.x, v3);
+        Fe25519.mul(p.x, p.x, u);    // x = u * v^3 * (u * v^7)^((p-5)/8)
+
+        Fe25519.sq(vxx, p.x);
+        Fe25519.mul(vxx, vxx, v);
+        Fe25519.sub(check, vxx, u);
+        if (!Fe25519.isZero(check)) {
+            Fe25519.add(check, vxx, u);
+            if (!Fe25519.isZero(check)) {
+                return null;         // not a square: the encoding is not a curve point
+            }
+            Fe25519.mul(p.x, p.x, SQRT_M1);
+        }
+
+        byte[] xb = new byte[32];
+        Fe25519.toBytes(xb, 0, p.x);
+        int wantSign = (s[off + 31] >>> 7) & 1;
+        if ((xb[0] & 1) != wantSign) {
+            Fe25519.sub(p.x, Fe25519.create(), p.x);
+            Fe25519.toBytes(xb, 0, p.x);
+            // x = 0 has only one encoding; asking for the odd one is invalid.
+            if ((xb[0] & 1) != wantSign) {
+                return null;
+            }
+        }
+
+        Fe25519.mul(p.t, p.x, p.y);
+        return p;
+    }
+
+    private static byte[] compress(Point p) {
+        int[] recip = Fe25519.create();
+        int[] x = Fe25519.create(), y = Fe25519.create();
+        Fe25519.invert(recip, p.z);
+        Fe25519.mul(x, p.x, recip);
+        Fe25519.mul(y, p.y, recip);
+
+        byte[] out = new byte[32];
+        Fe25519.toBytes(out, 0, y);
+        byte[] xb = new byte[32];
+        Fe25519.toBytes(xb, 0, x);
+        out[31] |= (byte) ((xb[0] & 1) << 7);
+        return out;
+    }
+
+    /** True if the little-endian 32-byte scalar is below the group order. */
+    private static boolean belowOrder(byte[] s, int off) {
+        for (int i = 31; i >= 0; i--) {
+            int a = s[off + i] & 0xff;
+            int b = L[i];
+            if (a < b) {
+                return true;
+            }
+            if (a > b) {
+                return false;
+            }
+        }
+        return false;   // equal to L is not below it
+    }
+
+    /**
+     * Verifies a signature over a message.
+     *
+     * @param publicKey 32 bytes
+     * @param signature 64 bytes: R followed by S
+     * @return true only if the signature is valid for this key and message
+     */
+    public static boolean verify(byte[] publicKey, byte[] message, byte[] signature) {
+        if (publicKey == null || publicKey.length != PUBLIC_KEY_LENGTH) {
+            return false;
+        }
+        if (signature == null || signature.length != SIGNATURE_LENGTH) {
+            return false;
+        }
+        if (!belowOrder(signature, 32)) {
+            return false;
+        }
+
+        Point a = decompress(publicKey, 0);
+        if (a == null) {
+            return false;
+        }
+        // R is checked implicitly: the comparison below is against its bytes.
+
+        SHA512 sha = new SHA512();
+        sha.update(signature, 0, 32);
+        sha.update(publicKey, 0, publicKey.length);
+        sha.update(message, 0, message.length);
+        byte[] k = sha.digest();
+
+        // RFC 8032 5.1.7 interprets the whole 64-octet digest as the scalar, so
+        // it is used unreduced; that costs extra doublings and no correctness.
+        Point ka = scalarMult(a, k, 512);
+
+        // S is the second half of the signature, and scalarMult indexes from
+        // the start of the array it is given.
+        byte[] s = new byte[32];
+        System.arraycopy(signature, 32, s, 0, 32);
+        Point sb = scalarMult(BASE, s, 253);
+
+        Point negKa = new Point();
+        negate(negKa, ka);
+        Point r = new Point();
+        add(r, sb, negKa);
+
+        byte[] expected = compress(r);
+        int diff = 0;
+        for (int i = 0; i < 32; i++) {
+            diff |= expected[i] ^ signature[i];
+        }
+        return diff == 0;
+    }
+}

--- a/ssh/src/berryssh/crypto/Fe25519.java
+++ b/ssh/src/berryssh/crypto/Fe25519.java
@@ -62,6 +62,19 @@ final class Fe25519 {
         }
     }
 
+    /**
+     * Renormalises limbs in place.
+     *
+     * {@link #add} and {@link #sub} deliberately skip carrying, so a chain of
+     * them can grow limbs past what {@link #mul} tolerates — its accumulator
+     * holds ten products scaled by 19, which only stays inside a signed 64-bit
+     * value while inputs are bounded by roughly 1.65 * 2^26. Call this on any
+     * value built from several additions before multiplying it.
+     */
+    static void reduce(int[] h) {
+        carry(h, h[0], h[1], h[2], h[3], h[4], h[5], h[6], h[7], h[8], h[9]);
+    }
+
     static void mul(int[] h, int[] f, int[] g) {
         int f0 = f[0], f1 = f[1], f2 = f[2], f3 = f[3], f4 = f[4];
         int f5 = f[5], f6 = f[6], f7 = f[7], f8 = f[8], f9 = f[9];

--- a/ssh/src/berryssh/crypto/SHA512.java
+++ b/ssh/src/berryssh/crypto/SHA512.java
@@ -1,0 +1,155 @@
+package berryssh.crypto;
+
+/**
+ * FIPS 180-4 SHA-512.
+ *
+ * Present because Ed25519 is defined over it (RFC 8032 §5.1); SSH itself uses
+ * SHA-256 for the exchange hash. Structurally the same as {@link SHA256} with
+ * 64-bit words, 80 rounds, and a 128-bit length field.
+ *
+ * Written for -source 1.3.
+ */
+public final class SHA512 {
+
+    public static final int DIGEST_LENGTH = 64;
+    private static final int BLOCK_LENGTH = 128;
+
+    private static final long[] K = {
+        0x428a2f98d728ae22L, 0x7137449123ef65cdL, 0xb5c0fbcfec4d3b2fL, 0xe9b5dba58189dbbcL,
+        0x3956c25bf348b538L, 0x59f111f1b605d019L, 0x923f82a4af194f9bL, 0xab1c5ed5da6d8118L,
+        0xd807aa98a3030242L, 0x12835b0145706fbeL, 0x243185be4ee4b28cL, 0x550c7dc3d5ffb4e2L,
+        0x72be5d74f27b896fL, 0x80deb1fe3b1696b1L, 0x9bdc06a725c71235L, 0xc19bf174cf692694L,
+        0xe49b69c19ef14ad2L, 0xefbe4786384f25e3L, 0x0fc19dc68b8cd5b5L, 0x240ca1cc77ac9c65L,
+        0x2de92c6f592b0275L, 0x4a7484aa6ea6e483L, 0x5cb0a9dcbd41fbd4L, 0x76f988da831153b5L,
+        0x983e5152ee66dfabL, 0xa831c66d2db43210L, 0xb00327c898fb213fL, 0xbf597fc7beef0ee4L,
+        0xc6e00bf33da88fc2L, 0xd5a79147930aa725L, 0x06ca6351e003826fL, 0x142929670a0e6e70L,
+        0x27b70a8546d22ffcL, 0x2e1b21385c26c926L, 0x4d2c6dfc5ac42aedL, 0x53380d139d95b3dfL,
+        0x650a73548baf63deL, 0x766a0abb3c77b2a8L, 0x81c2c92e47edaee6L, 0x92722c851482353bL,
+        0xa2bfe8a14cf10364L, 0xa81a664bbc423001L, 0xc24b8b70d0f89791L, 0xc76c51a30654be30L,
+        0xd192e819d6ef5218L, 0xd69906245565a910L, 0xf40e35855771202aL, 0x106aa07032bbd1b8L,
+        0x19a4c116b8d2d0c8L, 0x1e376c085141ab53L, 0x2748774cdf8eeb99L, 0x34b0bcb5e19b48a8L,
+        0x391c0cb3c5c95a63L, 0x4ed8aa4ae3418acbL, 0x5b9cca4f7763e373L, 0x682e6ff3d6b2b8a3L,
+        0x748f82ee5defb2fcL, 0x78a5636f43172f60L, 0x84c87814a1f0ab72L, 0x8cc702081a6439ecL,
+        0x90befffa23631e28L, 0xa4506cebde82bde9L, 0xbef9a3f7b2c67915L, 0xc67178f2e372532bL,
+        0xca273eceea26619cL, 0xd186b8c721c0c207L, 0xeada7dd6cde0eb1eL, 0xf57d4f7fee6ed178L,
+        0x06f067aa72176fbaL, 0x0a637dc5a2c898a6L, 0x113f9804bef90daeL, 0x1b710b35131c471bL,
+        0x28db77f523047d84L, 0x32caab7b40c72493L, 0x3c9ebe0a15c9bebcL, 0x431d67c49c100d4cL,
+        0x4cc5d4becb3e42b6L, 0x597f299cfc657e2aL, 0x5fcb6fab3ad6faecL, 0x6c44198c4a475817L
+    };
+
+    private final long[] h = new long[8];
+    private final long[] w = new long[80];
+    private final byte[] buffer = new byte[BLOCK_LENGTH];
+    private int bufferLength;
+    private long byteCount;
+
+    public SHA512() {
+        reset();
+    }
+
+    public void reset() {
+        h[0] = 0x6a09e667f3bcc908L; h[1] = 0xbb67ae8584caa73bL;
+        h[2] = 0x3c6ef372fe94f82bL; h[3] = 0xa54ff53a5f1d36f1L;
+        h[4] = 0x510e527fade682d1L; h[5] = 0x9b05688c2b3e6c1fL;
+        h[6] = 0x1f83d9abfb41bd6bL; h[7] = 0x5be0cd19137e2179L;
+        bufferLength = 0;
+        byteCount = 0;
+    }
+
+    public void update(byte[] input) {
+        update(input, 0, input.length);
+    }
+
+    public void update(byte[] input, int offset, int length) {
+        byteCount += length;
+        while (length > 0) {
+            int take = BLOCK_LENGTH - bufferLength;
+            if (take > length) {
+                take = length;
+            }
+            System.arraycopy(input, offset, buffer, bufferLength, take);
+            bufferLength += take;
+            offset += take;
+            length -= take;
+            if (bufferLength == BLOCK_LENGTH) {
+                processBlock(buffer);
+                bufferLength = 0;
+            }
+        }
+    }
+
+    public byte[] digest() {
+        long bitCount = byteCount << 3;
+
+        update(new byte[] { (byte) 0x80 }, 0, 1);
+        byte[] zero = new byte[1];
+        while (bufferLength != 112) {
+            update(zero, 0, 1);
+        }
+
+        // The length field is 128 bits; the high half is always zero for any
+        // input this code will ever see, so only the low 64 bits are written.
+        for (int i = 0; i < 8; i++) {
+            buffer[112 + i] = 0;
+        }
+        for (int i = 0; i < 8; i++) {
+            buffer[120 + i] = (byte) (bitCount >>> (56 - 8 * i));
+        }
+        processBlock(buffer);
+
+        byte[] out = new byte[DIGEST_LENGTH];
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 8; j++) {
+                out[8 * i + j] = (byte) (h[i] >>> (56 - 8 * j));
+            }
+        }
+        reset();
+        return out;
+    }
+
+    public static byte[] hash(byte[] input) {
+        SHA512 s = new SHA512();
+        s.update(input, 0, input.length);
+        return s.digest();
+    }
+
+    private void processBlock(byte[] block) {
+        for (int i = 0; i < 16; i++) {
+            long v = 0;
+            for (int j = 0; j < 8; j++) {
+                v = (v << 8) | (block[8 * i + j] & 0xffL);
+            }
+            w[i] = v;
+        }
+        for (int i = 16; i < 80; i++) {
+            long x = w[i - 15];
+            long y = w[i - 2];
+            long s0 = rotateRight(x, 1) ^ rotateRight(x, 8) ^ (x >>> 7);
+            long s1 = rotateRight(y, 19) ^ rotateRight(y, 61) ^ (y >>> 6);
+            w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+        }
+
+        long a = h[0], b = h[1], c = h[2], d = h[3];
+        long e = h[4], f = h[5], g = h[6], hh = h[7];
+
+        for (int i = 0; i < 80; i++) {
+            long s1 = rotateRight(e, 14) ^ rotateRight(e, 18) ^ rotateRight(e, 41);
+            long ch = (e & f) ^ (~e & g);
+            long t1 = hh + s1 + ch + K[i] + w[i];
+            long s0 = rotateRight(a, 28) ^ rotateRight(a, 34) ^ rotateRight(a, 39);
+            long maj = (a & b) ^ (a & c) ^ (b & c);
+            long t2 = s0 + maj;
+
+            hh = g; g = f; f = e; e = d + t1;
+            d = c; c = b; b = a; a = t1 + t2;
+        }
+
+        h[0] += a; h[1] += b; h[2] += c; h[3] += d;
+        h[4] += e; h[5] += f; h[6] += g; h[7] += hh;
+    }
+
+    /** CLDC 1.1 predates Long.rotateRight. */
+    private static long rotateRight(long v, int n) {
+        return (v >>> n) | (v << (64 - n));
+    }
+}


### PR DESCRIPTION
Closes #2.

Adds SHA-512 and Ed25519 verification, which the handshake needs to authenticate
an `ssh-ed25519` host key. Verification only — no private key is handled here,
so there is no secret and the scalar multiplication is a plain double-and-add
over public data.

### Constants are derived, not transcribed

`d` comes from -121665/121666, `sqrt(-1)` from an exponentiation, and the base
point from decompressing y = 4/5. Hand-copying 32-byte hex constants is a
realistic way to ship a subtly broken curve; deriving them costs a few field
inversions at class-load and makes that impossible.

### `Fe25519.reduce`, and the bug that motivated it

`add` and `sub` skip carrying by design, so a chain of them can grow limbs past
what `mul` tolerates — its accumulator holds ten products scaled by 19, and only
stays inside a signed 64-bit value while inputs stay near 1.65 × 2^26. Point
doubling builds `f = 2*Z^2 + (A - B)`, which reaches ~2^27 and overflowed
silently.

The symptom was worth recording. Results were correct for short scalars and
wrong for long ones, but not monotonically:

```
  bits   4  OK        bits  32  OK
  bits   8  OK        bits  48  OK
  bits  12  OK        bits  64  BAD
  bits  16  BAD       bits 128  BAD
```

That non-monotonic pattern is what says "value-dependent numeric overflow"
rather than a structural error — whether the accumulator overflows depends on
the limb values, not the iteration count. Bisecting against an independent
Python reference located it; `[L]B` failing to be the identity while `[3]B` was
correct was the first signal.

### Verification

```
PASS  SHA-512 empty / abc / two-block
PASS  Ed25519 RFC 8032 TEST 1 (empty message)
PASS  Ed25519 RFC 8032 TEST 2 (1-byte message)
PASS  Ed25519 RFC 8032 TEST 3 (2-byte message)
PASS  Ed25519 rejects a flipped signature bit
PASS  Ed25519 rejects a modified message
PASS  Ed25519 rejects the wrong public key
PASS  Ed25519 rejects S >= L
PASS  Ed25519 rejects a malformed length

28 passed, 0 failed
```

The negative cases carry most of the weight. A verifier that returns `false`
unconditionally passes all five of them, and one that returns `true`
unconditionally passes every RFC vector — during development this
implementation was in the first state, and only the positive vectors caught it.

`S >= L` is rejected per RFC 8032 §5.1.7, which is what stops a valid signature
from being reshaped into another valid one for the same message.