### PR TITLE
Implement the SSH transport: version exchange and packet framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Then open the printed URL in the device's native browser, over Wi-Fi.
 
 ## Verification
 
-`spike2/run.sh` compiles the crypto against the CLDC bootclasspath at
+`spike2/run.sh` compiles the client against the CLDC bootclasspath at
 `-source 1.3`, then runs its test vectors on the host JVM. Compiling under the
 device's constraints proves the code will run there; executing on the host
 proves it is correct. Neither half needs the device.
@@ -86,9 +86,15 @@ proves it is correct. Neither half needs the device.
 spike2/run.sh
 ```
 
-Current vectors: FIPS 180-4 for SHA-256 and SHA-512, RFC 8439 §2.4.2 / §2.5.2 /
+**Crypto**: FIPS 180-4 for SHA-256 and SHA-512, RFC 8439 §2.4.2 / §2.5.2 /
 §2.8.2 for ChaCha20, Poly1305 and the AEAD construction, RFC 7748 §5.2 / §6.1
 for X25519, and RFC 8032 §7.1 plus negative cases for Ed25519. 28 in total.
+
+**Transport**: RFC 4251 §5 for the wire types and RFC 4253 §6 for the packet
+framing, plus the version exchange and the paths that have to reject malformed
+input. 47 in total. They run under a Turkish default locale, which is the
+device's own and the setting most likely to break protocol code without raising
+an error anywhere.
 
 ## Measured on the device
 
@@ -111,7 +117,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
     lib/            dependency fetcher
     ssh/src/        the client library
     spike1/         device capability probe
-    spike2/         crypto test vectors
+    spike2/         test vectors, run on the host
     tools/          OTA server
 
 ## Status
@@ -120,7 +126,8 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] SHA-256, SHA-512, ChaCha20, Poly1305, ChaCha20-Poly1305 AEAD
 - [x] X25519 key agreement
 - [x] Ed25519 signature verification, and SHA-512
-- [ ] SSH transport: version exchange, binary packet protocol, KEXINIT
+- [x] SSH transport: version exchange and the binary packet protocol
+- [ ] KEXINIT algorithm negotiation, and the key exchange
 - [ ] `chacha20-poly1305@openssh.com` packet layer
 - [ ] User authentication
 - [ ] Channels, `pty-req`, shell

--- a/spike2/run.sh
+++ b/spike2/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Compile the crypto sources under CLDC 1.1 constraints, then run the test
+# Compile the client sources under CLDC 1.1 constraints, then run the test
 # vectors on the host JVM.
 #
 # The two halves are the point: compiling at -source 1.3 against the CLDC
@@ -17,23 +17,31 @@ trap 'rm -rf "$DOCKER_CONFIG"' EXIT
 rm -rf classes
 mkdir -p classes
 
-echo "==> compiling crypto under CLDC 1.1 / -source 1.3"
-docker run --rm \
+echo "==> compiling the client under CLDC 1.1 / -source 1.3"
+# javac's exit status is what decides this, not the presence of some class file:
+# a partial failure still leaves the earlier packages on disk, so counting
+# classes would let a package that does not build on the device pass unnoticed.
+# The filtering only applies to a successful run, where it is dropping the
+# -source 1.3 obsolescence notices.
+if ! cldc_output=$(docker run --rm \
     -v "$PWD/..:/client" -w /client/spike2 \
     eclipse-temurin:8-jdk \
     javac -source 1.3 -target 1.3 -nowarn \
           -bootclasspath /client/lib/cldcapi11.jar:/client/lib/midpapi20.jar \
           -d classes \
           $(cd .. && find ssh/src -name '*.java' | sed 's|^|/client/|' | tr '\n' ' ') \
-    2>&1 | grep -v 'obsolete\|deprecat\|warning' || true
-
-if [ -z "$(find classes -name '*.class' -print -quit)" ]; then
-    echo "crypto did not compile under CLDC constraints" >&2
+    2>&1); then
+    echo "$cldc_output" >&2
+    echo "the client did not compile under CLDC constraints" >&2
     exit 1
 fi
+echo "$cldc_output" | grep -v 'obsolete\|deprecat\|warning' || true
 
 echo "==> compiling tests (host JDK, sees the CLDC-built classes)"
-javac -nowarn -cp classes -d classes src/CryptoTests.java
+javac -nowarn -cp classes -d classes src/*.java
 
-echo "==> running vectors on host JVM"
+echo "==> running crypto vectors on host JVM"
 java -cp classes CryptoTests
+
+echo "==> running transport vectors on host JVM"
+java -cp classes TransportTests

--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -1,0 +1,398 @@
+import berryssh.protocol.Ascii;
+import berryssh.protocol.SshException;
+import berryssh.protocol.Transport;
+import berryssh.protocol.WireReader;
+import berryssh.protocol.WireWriter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Locale;
+
+/**
+ * Transport-layer vectors: the RFC 4251 section 5 wire types and the RFC 4253
+ * section 6 binary packet protocol.
+ *
+ * As with the crypto, the classes under test are compiled against the CLDC 1.1
+ * bootclasspath at -source 1.3 and then exercised here on the host JVM. This
+ * file is host-only and so is under no such restriction.
+ *
+ * Everything runs under a Turkish default locale on purpose. The device's
+ * locale is Turkish, and it is the one setting most likely to break protocol
+ * code silently — so the suite is run in the condition that would expose it
+ * rather than in the one that would hide it.
+ */
+public class TransportTests {
+
+    private static int passed;
+    private static int failed;
+
+    private interface Fallible {
+        void run() throws IOException;
+    }
+
+    public static void main(String[] args) {
+        Locale.setDefault(new Locale("tr", "TR"));
+
+        turkishLocaleIsLive();
+        wireTypeVectors();
+        wireRoundTrips();
+        nameListVectors();
+        mpintVectors();
+        packetFraming();
+        versionExchange();
+        malformedInput();
+
+        System.out.println();
+        System.out.println(passed + " passed, " + failed + " failed");
+        if (failed > 0) {
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Not a test of our code — a check that the hazard the protocol layer is
+     * written to avoid is actually present in this JVM. If this ever stops
+     * holding, the locale did not take and the rest of the suite is running
+     * under weaker conditions than it claims to.
+     */
+    private static void turkishLocaleIsLive() {
+        checkTrue("Turkish locale is in effect (case folding is lossy)",
+            !"I".toLowerCase().equals("i"));
+    }
+
+    /** RFC 4251 section 5. */
+    private static void wireTypeVectors() {
+        WireWriter w = new WireWriter();
+        w.writeByte(0x2a);
+        check("byte", w.toByteArray(), "2a");
+
+        w = new WireWriter();
+        w.writeBoolean(true);
+        w.writeBoolean(false);
+        check("boolean is 1 and 0", w.toByteArray(), "0100");
+
+        w = new WireWriter();
+        w.writeUint32(699921578L);
+        check("uint32 699921578", w.toByteArray(), "29b7f4aa");
+
+        w = new WireWriter();
+        w.writeUint32(0xffffffffL);
+        check("uint32 at the top of its range", w.toByteArray(), "ffffffff");
+
+        w = new WireWriter();
+        w.writeUint64(0x0102030405060708L);
+        check("uint64", w.toByteArray(), "0102030405060708");
+
+        w = new WireWriter();
+        w.writeAsciiString("testing");
+        check("string \"testing\"", w.toByteArray(), "0000000774657374696e67");
+
+        w = new WireWriter();
+        w.writeString(new byte[0]);
+        check("empty string", w.toByteArray(), "00000000");
+
+        // A string is arbitrary binary, not text: NUL and high bytes survive.
+        w = new WireWriter();
+        w.writeString(hex("00ff0080"));
+        check("string carries arbitrary binary", w.toByteArray(), "0000000400ff0080");
+    }
+
+    private static void wireRoundTrips() {
+        WireWriter w = new WireWriter();
+        w.writeByte(0xfe);
+        w.writeBoolean(true);
+        w.writeUint32(0xdeadbeefL);
+        w.writeUint64(0xfedcba9876543210L);
+        w.writeAsciiString("ssh-ed25519");
+        w.writeString(hex("00112233"));
+        w.writeMpint(hex("0080"));
+        w.writeNameList(new String[] { "curve25519-sha256", "ext-info-c" });
+
+        try {
+            WireReader r = new WireReader(w.toByteArray());
+            checkTrue("round trip: byte", r.readByte() == 0xfe);
+            checkTrue("round trip: boolean", r.readBoolean());
+            checkTrue("round trip: uint32 past the sign bit", r.readUint32() == 0xdeadbeefL);
+            checkTrue("round trip: uint64 past the sign bit", r.readUint64() == 0xfedcba9876543210L);
+            checkTrue("round trip: ascii string", "ssh-ed25519".equals(r.readAsciiString()));
+            check("round trip: string", r.readString(), "00112233");
+            check("round trip: mpint drops the sign byte", r.readMpint(), "80");
+            String[] names = r.readNameList();
+            checkTrue("round trip: name-list",
+                names.length == 2
+                    && "curve25519-sha256".equals(names[0])
+                    && "ext-info-c".equals(names[1]));
+            checkTrue("round trip consumed the whole buffer", r.remaining() == 0);
+        } catch (IOException e) {
+            fail("round trip threw " + e);
+        }
+    }
+
+    /** RFC 4251 section 5 name-list examples. */
+    private static void nameListVectors() {
+        WireWriter w = new WireWriter();
+        w.writeNameList(new String[0]);
+        check("name-list ()", w.toByteArray(), "00000000");
+
+        w = new WireWriter();
+        w.writeNameList(new String[] { "zlib" });
+        check("name-list (zlib)", w.toByteArray(), "000000047a6c6962");
+
+        w = new WireWriter();
+        w.writeNameList(new String[] { "zlib", "none" });
+        check("name-list (zlib,none)", w.toByteArray(), "000000097a6c69622c6e6f6e65");
+
+        try {
+            checkTrue("empty name-list reads back empty",
+                new WireReader(hex("00000000")).readNameList().length == 0);
+
+            // The dotted and dotless I are distinct names and must stay distinct.
+            // A case-insensitive match would fold them together under this locale.
+            WireWriter mixed = new WireWriter();
+            mixed.writeNameList(new String[] { "ID", "id" });
+            String[] names = new WireReader(mixed.toByteArray()).readNameList();
+            checkTrue("name-list comparison is exact, not case folded",
+                "ID".equals(names[0]) && "id".equals(names[1]) && !names[0].equals(names[1]));
+        } catch (IOException e) {
+            fail("name-list read threw " + e);
+        }
+    }
+
+    /** RFC 4251 section 5 mpint examples; SSH carries no negative values. */
+    private static void mpintVectors() {
+        WireWriter w = new WireWriter();
+        w.writeMpint(new byte[0]);
+        check("mpint 0", w.toByteArray(), "00000000");
+
+        w = new WireWriter();
+        w.writeMpint(hex("000000"));
+        check("mpint 0 written as leading zeroes", w.toByteArray(), "00000000");
+
+        w = new WireWriter();
+        w.writeMpint(hex("09a378f9b2e332a7"));
+        check("mpint 0x9a378f9b2e332a7", w.toByteArray(), "0000000809a378f9b2e332a7");
+
+        w = new WireWriter();
+        w.writeMpint(hex("80"));
+        check("mpint 0x80 gains a sign byte", w.toByteArray(), "000000020080");
+
+        w = new WireWriter();
+        w.writeMpint(hex("00000080"));
+        check("mpint strips leading zeroes before padding", w.toByteArray(), "000000020080");
+
+        // The shared secret arrives as 32 bytes and is hashed as an mpint, so a
+        // secret whose top byte is small must lose it rather than keep it.
+        w = new WireWriter();
+        w.writeMpint(hex("0011223344556677889900112233445566778899001122334455667788990011"));
+        check("mpint of a 32-byte secret with a small top byte",
+            w.toByteArray(),
+            "0000001f11223344556677889900112233445566778899001122334455667788990011");
+    }
+
+    private static void packetFraming() {
+        boolean allWellFormed = true;
+        boolean allRoundTripped = true;
+
+        // Every payload length across four block widths, so each alignment case
+        // and the 16-byte minimum are all hit.
+        for (int length = 0; length <= 40; length++) {
+            byte[] payload = new byte[length];
+            for (int i = 0; i < length; i++) {
+                payload[i] = (byte) (i + 1);
+            }
+
+            byte[] framed;
+            byte[] readBack;
+            try {
+                ByteArrayOutputStream sink = new ByteArrayOutputStream();
+                new Transport(new ByteArrayInputStream(new byte[0]), sink).writePacket(payload);
+                framed = sink.toByteArray();
+
+                readBack = new Transport(new ByteArrayInputStream(framed),
+                                         new ByteArrayOutputStream()).readPacket();
+            } catch (IOException e) {
+                fail("framing a " + length + "-byte payload threw " + e);
+                return;
+            }
+
+            long declared = ((long) (framed[0] & 0xff) << 24) | ((framed[1] & 0xff) << 16)
+                          | ((framed[2] & 0xff) << 8) | (framed[3] & 0xff);
+            int padLength = framed[4] & 0xff;
+
+            if (framed.length % 8 != 0
+                    || framed.length < 16
+                    || padLength < 4
+                    || declared != framed.length - 4
+                    || declared != 1 + length + padLength) {
+                allWellFormed = false;
+            }
+            if (!sameBytes(payload, readBack)) {
+                allRoundTripped = false;
+            }
+        }
+
+        checkTrue("packets of every payload length 0..40 obey the framing rules", allWellFormed);
+        checkTrue("packets of every payload length 0..40 round trip", allRoundTripped);
+    }
+
+    private static void versionExchange() {
+        // A banner, a bare-LF line ending, then a packet immediately behind the
+        // identification string — the last part is what catches a reader that
+        // buffers ahead and eats the first packet.
+        ByteArrayOutputStream framed = new ByteArrayOutputStream();
+        try {
+            new Transport(new ByteArrayInputStream(new byte[0]), framed)
+                .writePacket(Ascii.toBytes("first packet"));
+        } catch (IOException e) {
+            fail("could not build the trailing packet: " + e);
+            return;
+        }
+
+        ByteArrayOutputStream server = new ByteArrayOutputStream();
+        writeAscii(server, "Unauthorised access is prohibited.\r\n");
+        writeAscii(server, "SSH-2.0-OpenSSH_9.6\n");
+        byte[] packet = framed.toByteArray();
+        server.write(packet, 0, packet.length);
+
+        ByteArrayOutputStream client = new ByteArrayOutputStream();
+        Transport t = new Transport(new ByteArrayInputStream(server.toByteArray()), client);
+        try {
+            t.exchangeVersions();
+        } catch (IOException e) {
+            fail("version exchange threw " + e);
+            return;
+        }
+
+        check("client sends its identification with CR LF",
+            client.toByteArray(),
+            toHex(Ascii.toBytes("SSH-2.0-berryssh_0.1\r\n")));
+        checkTrue("banner lines are skipped and CR LF is stripped",
+            "SSH-2.0-OpenSSH_9.6".equals(t.serverVersion()));
+        checkTrue("client version is kept for the exchange hash",
+            "SSH-2.0-berryssh_0.1".equals(t.clientVersion()));
+
+        try {
+            checkTrue("the packet behind the identification string survives",
+                sameBytes(Ascii.toBytes("first packet"), t.readPacket()));
+        } catch (IOException e) {
+            fail("reading the packet after the version exchange threw " + e);
+        }
+
+        checkTrue("sequence numbers count what was sent and received",
+            t.sendSequence() == 0 && t.receiveSequence() == 1);
+
+        checkRejected("a version other than 2.0 is refused",
+            () -> transportOver("SSH-1.5-OpenSSH_2.9\r\n").exchangeVersions());
+        checkRejected("a closed connection during the exchange is refused",
+            () -> transportOver("no identification here\r\n").exchangeVersions());
+    }
+
+    private static void malformedInput() {
+        // packet_length of 0x00100000, past the cap, before any allocation.
+        checkRejected("an implausible packet length is refused",
+            () -> transportOver(hex("00100000")).readPacket());
+        checkRejected("a packet below the minimum size is refused",
+            () -> transportOver(hex("00000004" + "04000000")).readPacket());
+        checkRejected("a packet that is not a whole number of blocks is refused",
+            () -> transportOver(hex("0000000d" + "040000000000000000000000")).readPacket());
+        checkRejected("padding shorter than 4 bytes is refused",
+            () -> transportOver(hex("0000000c" + "030000000000000000000000")).readPacket());
+        checkRejected("padding larger than the packet is refused",
+            () -> transportOver(hex("0000000c" + "ff0000000000000000000000")).readPacket());
+        checkRejected("a truncated packet is refused",
+            () -> transportOver(hex("0000000c" + "0400")).readPacket());
+
+        checkRejected("a field running past the end is refused",
+            () -> new WireReader(hex("000000")).readUint32());
+        checkRejected("a string length overrunning the packet is refused",
+            () -> new WireReader(hex("7fffffff00")).readString());
+        checkRejected("a negative mpint is refused",
+            () -> new WireReader(hex("00000002edcc")).readMpint());
+    }
+
+    private static Transport transportOver(String ascii) {
+        return transportOver(Ascii.toBytes(ascii));
+    }
+
+    private static Transport transportOver(byte[] data) {
+        return new Transport(new ByteArrayInputStream(data), new ByteArrayOutputStream());
+    }
+
+    private static void writeAscii(ByteArrayOutputStream out, String s) {
+        byte[] b = Ascii.toBytes(s);
+        out.write(b, 0, b.length);
+    }
+
+    private static boolean sameBytes(byte[] a, byte[] b) {
+        if (a.length != b.length) {
+            return false;
+        }
+        for (int i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void checkRejected(String name, Fallible f) {
+        try {
+            f.run();
+            fail(name + " (nothing was thrown)");
+        } catch (SshException e) {
+            pass(name);
+        } catch (IOException e) {
+            fail(name + " (threw " + e + " rather than SshException)");
+        }
+    }
+
+    private static void check(String name, byte[] actual, String expectedHex) {
+        String got = toHex(actual);
+        if (got.equals(expectedHex)) {
+            pass(name);
+        } else {
+            fail(name);
+            System.out.println("        expected " + expectedHex);
+            System.out.println("        actual   " + got);
+        }
+    }
+
+    private static void checkTrue(String name, boolean condition) {
+        if (condition) {
+            pass(name);
+        } else {
+            fail(name);
+        }
+    }
+
+    private static void pass(String name) {
+        passed++;
+        System.out.println("  PASS  " + name);
+    }
+
+    private static void fail(String name) {
+        failed++;
+        System.out.println("  FAIL  " + name);
+    }
+
+    private static byte[] hex(String s) {
+        byte[] b = new byte[s.length() / 2];
+        for (int i = 0; i < b.length; i++) {
+            b[i] = (byte) Integer.parseInt(s.substring(2 * i, 2 * i + 2), 16);
+        }
+        return b;
+    }
+
+    private static String toHex(byte[] b) {
+        StringBuffer sb = new StringBuffer(b.length * 2);
+        for (int i = 0; i < b.length; i++) {
+            int v = b[i] & 0xff;
+            if (v < 16) {
+                sb.append('0');
+            }
+            sb.append(Integer.toHexString(v));
+        }
+        return sb.toString();
+    }
+}

--- a/ssh/src/berryssh/protocol/Ascii.java
+++ b/ssh/src/berryssh/protocol/Ascii.java
@@ -1,0 +1,41 @@
+package berryssh.protocol;
+
+/**
+ * US-ASCII conversion, done by hand.
+ *
+ * Neither direction can be left to the platform here. The device's default
+ * encoding is ISO8859_1, so {@code new String(byte[])} is not portable, and its
+ * locale is Turkish, where {@code "I".toLowerCase()} is {@code "i-dotless"} —
+ * an algorithm name run through a case fold would stop matching with no error
+ * anywhere. Protocol names are US-ASCII by RFC 4251, so they are converted a
+ * byte at a time and compared with String.equals, which is code-point equality
+ * and carries no locale.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Ascii {
+
+    private Ascii() {
+    }
+
+    /** Truncates to the low 8 bits; callers pass names that are ASCII by specification. */
+    public static byte[] toBytes(String s) {
+        byte[] b = new byte[s.length()];
+        for (int i = 0; i < s.length(); i++) {
+            b[i] = (byte) s.charAt(i);
+        }
+        return b;
+    }
+
+    public static String fromBytes(byte[] b) {
+        return fromBytes(b, 0, b.length);
+    }
+
+    public static String fromBytes(byte[] b, int offset, int length) {
+        char[] c = new char[length];
+        for (int i = 0; i < length; i++) {
+            c[i] = (char) (b[offset + i] & 0xff);
+        }
+        return new String(c);
+    }
+}

--- a/ssh/src/berryssh/protocol/SshException.java
+++ b/ssh/src/berryssh/protocol/SshException.java
@@ -1,0 +1,17 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+/**
+ * A protocol error.
+ *
+ * It extends IOException so that a caller driving the connection needs one
+ * catch for both a broken socket and a malformed packet: at that level the
+ * remedy is the same either way, which is to drop the connection.
+ */
+public class SshException extends IOException {
+
+    public SshException(String message) {
+        super(message);
+    }
+}

--- a/ssh/src/berryssh/protocol/Transport.java
+++ b/ssh/src/berryssh/protocol/Transport.java
@@ -1,0 +1,244 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Random;
+
+/**
+ * The RFC 4253 transport layer: the version exchange, and the binary packet
+ * protocol that frames everything above it.
+ *
+ * This class deliberately knows nothing about MIDP. It is driven through plain
+ * java.io streams so the whole framing layer can be exercised on the host
+ * against a pair of byte arrays, with no device and no server involved.
+ *
+ * The packets are still in the clear here. Once the key exchange has run,
+ * chacha20-poly1305 replaces both the padding rules and the length field's
+ * encoding, because that cipher encrypts the length separately — so this is a
+ * seam the cipher work will reopen, not a finished layer.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Transport {
+
+    public static final String SOFTWARE_VERSION = "berryssh_0.1";
+
+    private static final String IDENTIFICATION = "SSH-2.0-" + SOFTWARE_VERSION;
+
+    /** RFC 4253 section 4.2: the identification line including CR LF is at most 255 bytes. */
+    private static final int MAX_VERSION_LINE = 255;
+
+    /** A server may precede its identification with banner text; it may not do so forever. */
+    private static final int MAX_BANNER_LINES = 1024;
+
+    /**
+     * RFC 4253 requires 35000 bytes to be accepted. The bound is generous
+     * rather than tight because it exists to stop a hostile length field from
+     * turning into an allocation, not to constrain a real server.
+     */
+    private static final int MAX_PACKET = 256 * 1024;
+
+    /** Smallest legal packet, counting the length field itself. */
+    private static final int MIN_PACKET = 16;
+
+    private final InputStream in;
+    private final OutputStream out;
+
+    /**
+     * Padding only has to be unpredictable enough to satisfy RFC 4253's SHOULD.
+     * It is not key material: before the key exchange it travels in the clear
+     * with nothing to hide, and afterwards the AEAD covers it. Generating a
+     * private key needs a real entropy source, which this is not.
+     */
+    private final Random paddingSource = new Random(System.currentTimeMillis());
+
+    /**
+     * Eight until a cipher is negotiated. RFC 4253 sets the alignment to the
+     * cipher's block size, or 8 for a stream cipher and for the null cipher.
+     */
+    private int blockSize = 8;
+
+    private String clientVersion;
+    private String serverVersion;
+    private long sendSequence;
+    private long receiveSequence;
+
+    public Transport(InputStream in, OutputStream out) {
+        this.in = in;
+        this.out = out;
+    }
+
+    /** The client's identification line, without CR LF, as it feeds the exchange hash. */
+    public String clientVersion() {
+        return clientVersion;
+    }
+
+    /** The server's identification line, without CR LF, as it feeds the exchange hash. */
+    public String serverVersion() {
+        return serverVersion;
+    }
+
+    public long sendSequence() {
+        return sendSequence;
+    }
+
+    public long receiveSequence() {
+        return receiveSequence;
+    }
+
+    /**
+     * Sends our identification line and reads the peer's.
+     *
+     * Both strings are kept because the key exchange hashes them: getting them
+     * back by reconstruction later would risk a mismatch over CR LF or over a
+     * banner line, and the hash would fail with nothing to point at.
+     */
+    public void exchangeVersions() throws IOException {
+        clientVersion = IDENTIFICATION;
+        out.write(Ascii.toBytes(clientVersion));
+        out.write('\r');
+        out.write('\n');
+        out.flush();
+
+        // RFC 4253 section 4.2 lets a server send any number of other lines
+        // first. Everything before the SSH- line is banner text and is dropped.
+        String line = null;
+        for (int i = 0; i < MAX_BANNER_LINES; i++) {
+            line = readLine();
+            if (line.startsWith("SSH-")) {
+                break;
+            }
+            line = null;
+        }
+        if (line == null) {
+            throw new SshException("no identification string after " + MAX_BANNER_LINES + " lines");
+        }
+
+        // "1.99" means a server that also speaks 2.0.
+        if (!line.startsWith("SSH-2.0-") && !line.startsWith("SSH-1.99-")) {
+            throw new SshException("unsupported protocol version: " + line);
+        }
+        serverVersion = line;
+    }
+
+    /**
+     * Frames a payload and writes it.
+     *
+     * RFC 4253 section 6: the length field, the padding-length byte, the
+     * payload and the padding together come to a multiple of the block size,
+     * with at least 4 bytes of padding and at least 16 bytes in total.
+     */
+    public void writePacket(byte[] payload) throws IOException {
+        int unpadded = 5 + payload.length;
+        int padLength = blockSize - (unpadded % blockSize);
+        if (padLength < 4) {
+            padLength += blockSize;
+        }
+        while (unpadded + padLength < MIN_PACKET) {
+            padLength += blockSize;
+        }
+
+        int packetLength = 1 + payload.length + padLength;
+        byte[] packet = new byte[4 + packetLength];
+        packet[0] = (byte) (packetLength >>> 24);
+        packet[1] = (byte) (packetLength >>> 16);
+        packet[2] = (byte) (packetLength >>> 8);
+        packet[3] = (byte) packetLength;
+        packet[4] = (byte) padLength;
+        System.arraycopy(payload, 0, packet, 5, payload.length);
+        fillRandom(packet, 5 + payload.length, padLength);
+
+        out.write(packet, 0, packet.length);
+        out.flush();
+        sendSequence = (sendSequence + 1) & 0xffffffffL;
+    }
+
+    /** Reads one packet and returns its payload. */
+    public byte[] readPacket() throws IOException {
+        byte[] header = new byte[4];
+        readFully(header, 0, 4);
+        long packetLength = ((long) (header[0] & 0xff) << 24)
+                          | ((long) (header[1] & 0xff) << 16)
+                          | ((long) (header[2] & 0xff) << 8)
+                          | (long) (header[3] & 0xff);
+
+        // Every check here happens before the allocation on the next line.
+        if (packetLength < MIN_PACKET - 4) {
+            throw new SshException("packet of " + packetLength + " bytes is below the minimum");
+        }
+        if (packetLength > MAX_PACKET) {
+            throw new SshException("packet of " + packetLength + " bytes is implausible");
+        }
+        if ((packetLength + 4) % blockSize != 0) {
+            throw new SshException("packet is not a whole number of " + blockSize + "-byte blocks");
+        }
+
+        byte[] body = new byte[(int) packetLength];
+        readFully(body, 0, body.length);
+
+        int padLength = body[0] & 0xff;
+        if (padLength < 4 || padLength > body.length - 1) {
+            throw new SshException("padding of " + padLength + " bytes does not fit the packet");
+        }
+
+        byte[] payload = new byte[body.length - padLength - 1];
+        System.arraycopy(body, 1, payload, 0, payload.length);
+        receiveSequence = (receiveSequence + 1) & 0xffffffffL;
+        return payload;
+    }
+
+    /**
+     * Reads one CR-LF-terminated line, a byte at a time.
+     *
+     * Reading ahead in blocks would swallow the first packet, and CLDC has no
+     * BufferedInputStream to push the excess back into. The 255-byte cap counts
+     * only what is kept, which is marginally more tolerant than the RFC — worth
+     * it to not reject a server over its line ending.
+     */
+    private String readLine() throws IOException {
+        byte[] line = new byte[MAX_VERSION_LINE];
+        int n = 0;
+        for (;;) {
+            int c = in.read();
+            if (c < 0) {
+                throw new SshException("connection closed during the version exchange");
+            }
+            if (c == '\n') {
+                break;
+            }
+            if (n == line.length) {
+                throw new SshException("version line longer than " + MAX_VERSION_LINE + " bytes");
+            }
+            line[n++] = (byte) c;
+        }
+        if (n > 0 && line[n - 1] == '\r') {
+            n--;
+        }
+        return Ascii.fromBytes(line, 0, n);
+    }
+
+    private void readFully(byte[] b, int offset, int length) throws IOException {
+        while (length > 0) {
+            int n = in.read(b, offset, length);
+            if (n < 0) {
+                throw new SshException("connection closed mid-packet");
+            }
+            offset += n;
+            length -= n;
+        }
+    }
+
+    /** CLDC's Random has no nextBytes, so the words are unpacked by hand. */
+    private void fillRandom(byte[] b, int offset, int length) {
+        while (length > 0) {
+            int word = paddingSource.nextInt();
+            int take = length < 4 ? length : 4;
+            for (int i = 0; i < take; i++) {
+                b[offset + i] = (byte) (word >>> (8 * i));
+            }
+            offset += take;
+            length -= take;
+        }
+    }
+}

--- a/ssh/src/berryssh/protocol/WireReader.java
+++ b/ssh/src/berryssh/protocol/WireReader.java
@@ -1,0 +1,140 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+/**
+ * Reader for the SSH wire types of RFC 4251 section 5.
+ *
+ * Every read is bounds-checked against the end of the packet. The data is
+ * attacker-controlled up until the host key is verified, so a length field is
+ * never trusted far enough to allocate against before it has been compared with
+ * what is actually left.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class WireReader {
+
+    private final byte[] buf;
+    private final int end;
+    private int pos;
+
+    public WireReader(byte[] data) {
+        this(data, 0, data.length);
+    }
+
+    public WireReader(byte[] data, int offset, int length) {
+        this.buf = data;
+        this.pos = offset;
+        this.end = offset + length;
+    }
+
+    public int remaining() {
+        return end - pos;
+    }
+
+    /** Returns 0..255, not a sign-extended byte. */
+    public int readByte() throws IOException {
+        need(1);
+        return buf[pos++] & 0xff;
+    }
+
+    public boolean readBoolean() throws IOException {
+        return readByte() != 0;
+    }
+
+    /** Returns 0..2^32-1: a uint32 does not fit in a Java int without a sign trap. */
+    public long readUint32() throws IOException {
+        need(4);
+        return ((long) (buf[pos++] & 0xff) << 24)
+             | ((long) (buf[pos++] & 0xff) << 16)
+             | ((long) (buf[pos++] & 0xff) << 8)
+             | (long) (buf[pos++] & 0xff);
+    }
+
+    public long readUint64() throws IOException {
+        need(8);
+        long v = 0;
+        for (int i = 0; i < 8; i++) {
+            v = (v << 8) | (buf[pos++] & 0xff);
+        }
+        return v;
+    }
+
+    /** Reads bytes with no length prefix. */
+    public byte[] readRaw(int length) throws IOException {
+        need(length);
+        byte[] out = new byte[length];
+        System.arraycopy(buf, pos, out, 0, length);
+        pos += length;
+        return out;
+    }
+
+    public byte[] readString() throws IOException {
+        long length = readUint32();
+        // Compared before allocating: the length is the peer's to choose.
+        if (length > remaining()) {
+            throw new SshException("string of " + length + " bytes overruns the packet");
+        }
+        return readRaw((int) length);
+    }
+
+    public String readAsciiString() throws IOException {
+        return Ascii.fromBytes(readString());
+    }
+
+    /**
+     * An mpint, returned as an unsigned big-endian magnitude with the sign byte
+     * and any leading zeroes removed. SSH carries no negative values, so one
+     * arriving is a protocol error rather than something to represent.
+     */
+    public byte[] readMpint() throws IOException {
+        byte[] v = readString();
+        if (v.length == 0) {
+            return new byte[0];
+        }
+        if ((v[0] & 0x80) != 0) {
+            throw new SshException("negative mpint");
+        }
+        int start = 0;
+        while (start < v.length && v[start] == 0) {
+            start++;
+        }
+        byte[] magnitude = new byte[v.length - start];
+        System.arraycopy(v, start, magnitude, 0, magnitude.length);
+        return magnitude;
+    }
+
+    /**
+     * A name-list. The names come back as Strings built by {@link Ascii}, so a
+     * later comparison with String.equals is byte equality — see the note there
+     * on why a case-insensitive match would be a bug on this device.
+     */
+    public String[] readNameList() throws IOException {
+        byte[] b = readString();
+        if (b.length == 0) {
+            return new String[0];
+        }
+        int count = 1;
+        for (int i = 0; i < b.length; i++) {
+            if (b[i] == ',') {
+                count++;
+            }
+        }
+        String[] names = new String[count];
+        int n = 0;
+        int start = 0;
+        for (int i = 0; i <= b.length; i++) {
+            if (i == b.length || b[i] == ',') {
+                names[n++] = Ascii.fromBytes(b, start, i - start);
+                start = i + 1;
+            }
+        }
+        return names;
+    }
+
+    private void need(int n) throws IOException {
+        if (n < 0 || end - pos < n) {
+            throw new SshException("packet ended mid-field");
+        }
+    }
+}

--- a/ssh/src/berryssh/protocol/WireWriter.java
+++ b/ssh/src/berryssh/protocol/WireWriter.java
@@ -1,0 +1,149 @@
+package berryssh.protocol;
+
+/**
+ * Writer for the SSH wire types of RFC 4251 section 5.
+ *
+ * Everything SSH sends is built out of these six types, so the encoding rules
+ * live in one place rather than being open-coded per message. The buffer grows
+ * on demand: packet sizes are not known ahead of time and CLDC has no
+ * ByteArrayOutputStream variant that would hand back the backing array without
+ * a copy.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class WireWriter {
+
+    private byte[] buf;
+    private int pos;
+
+    public WireWriter() {
+        this(256);
+    }
+
+    public WireWriter(int capacity) {
+        buf = new byte[capacity < 16 ? 16 : capacity];
+    }
+
+    public int length() {
+        return pos;
+    }
+
+    public byte[] toByteArray() {
+        byte[] out = new byte[pos];
+        System.arraycopy(buf, 0, out, 0, pos);
+        return out;
+    }
+
+    public void writeByte(int b) {
+        ensure(1);
+        buf[pos++] = (byte) b;
+    }
+
+    /** RFC 4251: a sender must use 1 for true, not merely a non-zero byte. */
+    public void writeBoolean(boolean v) {
+        writeByte(v ? 1 : 0);
+    }
+
+    /** Takes a long so that the full unsigned range survives the call unambiguously. */
+    public void writeUint32(long v) {
+        ensure(4);
+        buf[pos++] = (byte) (v >>> 24);
+        buf[pos++] = (byte) (v >>> 16);
+        buf[pos++] = (byte) (v >>> 8);
+        buf[pos++] = (byte) v;
+    }
+
+    public void writeUint64(long v) {
+        ensure(8);
+        for (int shift = 56; shift >= 0; shift -= 8) {
+            buf[pos++] = (byte) (v >>> shift);
+        }
+    }
+
+    /** Appends bytes with no length prefix. */
+    public void writeRaw(byte[] b) {
+        writeRaw(b, 0, b.length);
+    }
+
+    public void writeRaw(byte[] b, int offset, int length) {
+        ensure(length);
+        System.arraycopy(b, offset, buf, pos, length);
+        pos += length;
+    }
+
+    /** An SSH string is a length prefix and arbitrary binary, not text. */
+    public void writeString(byte[] s) {
+        writeString(s, 0, s.length);
+    }
+
+    public void writeString(byte[] s, int offset, int length) {
+        writeUint32(length);
+        writeRaw(s, offset, length);
+    }
+
+    /**
+     * A string holding an ASCII name — a service, an algorithm, a channel type.
+     * Named for the encoding on purpose: usernames and passwords are UTF-8 by
+     * RFC 4252 and must not come through here.
+     */
+    public void writeAsciiString(String s) {
+        writeString(Ascii.toBytes(s));
+    }
+
+    /**
+     * An mpint, from an unsigned big-endian magnitude.
+     *
+     * RFC 4251 stores these in two's complement at minimum length: leading zero
+     * bytes are dropped, and a zero byte goes in front when the top bit is set
+     * so the value stays positive. Zero is the empty string. SSH never carries a
+     * negative one, so only the non-negative case is encoded.
+     */
+    public void writeMpint(byte[] magnitude) {
+        int start = 0;
+        while (start < magnitude.length && magnitude[start] == 0) {
+            start++;
+        }
+        int length = magnitude.length - start;
+        if (length == 0) {
+            writeUint32(0);
+            return;
+        }
+        boolean signByte = (magnitude[start] & 0x80) != 0;
+        writeUint32(signByte ? length + 1 : length);
+        if (signByte) {
+            writeByte(0);
+        }
+        writeRaw(magnitude, start, length);
+    }
+
+    /** A name-list: comma-separated ASCII names, carried inside a string. */
+    public void writeNameList(String[] names) {
+        int total = 0;
+        for (int i = 0; i < names.length; i++) {
+            if (i > 0) {
+                total++;
+            }
+            total += names[i].length();
+        }
+        writeUint32(total);
+        for (int i = 0; i < names.length; i++) {
+            if (i > 0) {
+                writeByte(',');
+            }
+            writeRaw(Ascii.toBytes(names[i]));
+        }
+    }
+
+    private void ensure(int extra) {
+        if (pos + extra <= buf.length) {
+            return;
+        }
+        int size = buf.length * 2;
+        while (size < pos + extra) {
+            size *= 2;
+        }
+        byte[] bigger = new byte[size];
+        System.arraycopy(buf, 0, bigger, 0, pos);
+        buf = bigger;
+    }
+}


### PR DESCRIPTION
Closes #3.

The framing everything above it sits on: the RFC 4253 version exchange and
binary packet protocol, and the RFC 4251 §5 wire types they are built from.

`berryssh.protocol` — `Transport`, `WireReader`, `WireWriter`, `Ascii`,
`SshException`. `Transport` is driven through plain `java.io` streams and
touches no MIDP, so the whole framing layer is exercised on the host against a
pair of byte arrays, with no device and no server involved.

### What the platform decided

- **`java.util.Random` has no `nextBytes` in CLDC 1.1.** It compiles against the
  host JDK and fails only under the CLDC bootclasspath. Padding unpacks
  `nextInt()` by hand. That source is *not* a CSPRNG — padding is in the clear
  before the key exchange and under the AEAD after it, so it never needs to be
  secret. Key generation does, and this cannot supply it (see below).
- **No `BufferedInputStream` in CLDC**, so the version line is read a byte at a
  time. Reading ahead would swallow the first packet and there is nothing to
  push the excess back into — a test puts a packet directly behind the
  identification string and reads it back.
- **No `BigInteger`**, so `mpint` is encoded from an unsigned magnitude. The
  shared secret arrives as 32 bytes and is hashed as an mpint, so the
  leading-zero and sign-byte rules feed the exchange hash rather than being
  decoration.
- **Turkish locale**, so name-lists compare byte for byte. The whole transport
  suite runs under a `tr-TR` default locale, and asserts the hazard is genuinely
  live in that JVM so the suite cannot quietly weaken into testing nothing.

The packet layer is deliberately left unabstracted: `chacha20-poly1305`
encrypts the length field separately, so #6 will reopen this seam rather than
slot into a cipher interface guessed at now.

### Harness fix

The CLDC compile step decided it had succeeded by finding at least one class
file. A partial failure leaves the earlier packages on disk, so a new package
that does not build for the device would have passed unnoticed — precisely what
the `nextBytes` trap above would have produced. It now checks `javac`'s exit
status, verified by feeding it that trap on purpose.

### Verification

`spike2/run.sh` — 28 crypto vectors and 47 transport vectors, 0 failures. All
five new classes build at class file version 47 against the CLDC bootclasspath.

Transport vectors cover the RFC 4251 §5 encodings (`uint32` 699921578, string
`"testing"`, the mpint and name-list examples), reader/writer round trips,
every payload length 0..40 against the framing rules, the version exchange with
a banner line and a bare-LF ending, and nine malformed-input paths that must be
rejected.

### One gap this surfaced

Nothing in the issue list covers a random source, and #5 needs a real one for
the ephemeral X25519 scalar. `java.util.Random` seeded from the clock is not
adequate for a private key, and CLDC offers nothing better — entropy on this
device is an open question that should be settled before #5, not during it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)