### PR TITLE
Add a random source for key material

### DIFF
--- a/spike2/src/CryptoTests.java
+++ b/spike2/src/CryptoTests.java
@@ -1,4 +1,5 @@
 import berryssh.crypto.ChaCha20;
+import berryssh.crypto.EntropyPool;
 import berryssh.crypto.Poly1305;
 import berryssh.crypto.Ed25519;
 import berryssh.crypto.SHA256;
@@ -25,6 +26,7 @@ public class CryptoTests {
         x25519Vectors();
         sha512Vectors();
         ed25519Vectors();
+        entropyPoolVectors();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -274,6 +276,114 @@ public class CryptoTests {
     private static void writeLong(byte[] b, int off, long v) {
         for (int i = 0; i < 8; i++) {
             b[off + i] = (byte) (v >>> (8 * i));
+        }
+    }
+
+    /**
+     * The DRBG, against vectors computed independently in Python rather than
+     * against itself. The entropy estimate behind it is a judgement and cannot
+     * be tested; the construction that consumes it can.
+     */
+    private static void entropyPoolVectors() {
+        byte[] seed = new byte[32];
+        for (int i = 0; i < 32; i++) {
+            seed[i] = (byte) i;
+        }
+
+        check("DRBG from a stored seed",
+            new EntropyPool(seed).nextBytes(32),
+            "e106ca62126029d91ef7be33ccf0110a724e9b867ed0e7396098478194fe828c");
+
+        check("DRBG second block within one call",
+            tail(new EntropyPool(seed).nextBytes(64), 32),
+            "c2b2111d253dbb833506c9304714552f99769ca3df6d8005556d8e492c3fbb2c");
+
+        // A separate call must not continue where the last one stopped: the
+        // finalising ratchet moves the state on, which is what stops a
+        // recovered pool from reproducing bytes already handed out.
+        EntropyPool sequential = new EntropyPool(seed);
+        sequential.nextBytes(32);
+        check("DRBG ratchets between calls, not just within one",
+            sequential.nextBytes(32),
+            "c7d98b8dff6e52d5d2c7b077e88072e571a5d42e12cc0132ba194b07ba35148a");
+
+        checkTrue("DRBG diverges for a different seed",
+            !toHex(new EntropyPool(seed).nextBytes(32))
+                .equals(toHex(new EntropyPool(new byte[32]).nextBytes(32))));
+
+        boolean lengthsCorrect = true;
+        int[] lengths = { 1, 16, 31, 32, 33, 64, 100 };
+        for (int i = 0; i < lengths.length; i++) {
+            if (new EntropyPool(seed).nextBytes(lengths[i]).length != lengths[i]) {
+                lengthsCorrect = false;
+            }
+        }
+        checkTrue("DRBG returns the length asked for, across block boundaries", lengthsCorrect);
+
+        // The gate is the point of the class: weak bytes returned quietly would
+        // never be noticed, so an under-seeded pool must fail loudly instead.
+        EntropyPool cold = new EntropyPool();
+        checkTrue("a fresh pool is not seeded", !cold.isSeeded() && cold.seededBits() == 0);
+        boolean refused = false;
+        try {
+            cold.nextBytes(32);
+        } catch (IllegalStateException e) {
+            refused = true;
+        }
+        checkTrue("an under-seeded pool refuses to generate", refused);
+
+        // Uncredited samples must not open the gate, however many arrive.
+        EntropyPool guessable = new EntropyPool();
+        for (int i = 0; i < 100; i++) {
+            guessable.addPlatformState();
+        }
+        checkTrue("platform state alone does not seed the pool", !guessable.isSeeded());
+
+        EntropyPool harvested = new EntropyPool();
+        harvested.seed();
+        checkTrue("seed() reaches the requirement and then generates",
+            harvested.isSeeded()
+                && harvested.seededBits() == EntropyPool.REQUIRED_BITS
+                && harvested.nextBytes(32).length == 32);
+
+        // Not a proof of randomness — a check that the output is not degenerate,
+        // which is what a wiring mistake in the DRBG would actually look like.
+        byte[] bulk = new EntropyPool(seed).nextBytes(8192);
+        boolean[] seen = new boolean[256];
+        int ones = 0;
+        for (int i = 0; i < bulk.length; i++) {
+            int v = bulk[i] & 0xff;
+            seen[v] = true;
+            for (int bit = 0; bit < 8; bit++) {
+                if ((v & (1 << bit)) != 0) {
+                    ones++;
+                }
+            }
+        }
+        boolean allSeen = true;
+        for (int i = 0; i < 256; i++) {
+            if (!seen[i]) {
+                allSeen = false;
+            }
+        }
+        int totalBits = bulk.length * 8;
+        checkTrue("DRBG output covers every byte value and is bit-balanced",
+            allSeen && Math.abs(ones - totalBits / 2) < totalBits / 40);
+    }
+
+    private static byte[] tail(byte[] b, int n) {
+        byte[] out = new byte[n];
+        System.arraycopy(b, b.length - n, out, 0, n);
+        return out;
+    }
+
+    private static void checkTrue(String name, boolean condition) {
+        if (condition) {
+            passed++;
+            System.out.println("  PASS  " + name);
+        } else {
+            failed++;
+            System.out.println("  FAIL  " + name);
         }
     }
 

--- a/ssh/src/berryssh/crypto/EntropyPool.java
+++ b/ssh/src/berryssh/crypto/EntropyPool.java
@@ -1,0 +1,219 @@
+package berryssh.crypto;
+
+/**
+ * The random source for key material.
+ *
+ * CLDC 1.1 has no SecureRandom, and java.util.Random is a 48-bit LCG seeded
+ * from the clock — an attacker who knows the connection time to within a second
+ * has a few thousand candidate seeds, which is not a key. RIM's random is a
+ * protected API and therefore unavailable to us by design. So the pool is built
+ * from what the platform will actually give up.
+ *
+ * The construction is a SHA-256 DRBG. Samples are absorbed into a 32-byte
+ * state; generation ratchets that state forward before each output block and
+ * once more afterwards, so the state left in memory cannot reproduce anything
+ * already handed out.
+ *
+ * The constructors are deterministic on purpose — the platform sampling is a
+ * separate call rather than something a constructor does behind the caller's
+ * back. That keeps the DRBG itself testable, and it costs nothing, because the
+ * platform values are not credited as entropy anyway. Ordinary callers want
+ * {@link #seed}.
+ *
+ * <b>The entropy estimate is a judgement, not a measurement.</b> Each jitter
+ * sample is credited 2 bits, deliberately below what the technique is generally
+ * thought to yield, because the cost of over-crediting is a predictable private
+ * key. {@link #isSeeded} gates key material on {@link #REQUIRED_BITS}, and
+ * refusing to generate is the right behaviour when the pool is short — quietly
+ * returning weak bytes is the failure nobody would ever notice.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class EntropyPool {
+
+    /** A full-strength key's worth. Nothing is handed out before the pool reaches it. */
+    public static final int REQUIRED_BITS = 256;
+
+    /** Credited per jitter sample. See the note above on why this is pessimistic. */
+    private static final int BITS_PER_JITTER_SAMPLE = 2;
+
+    /** Credited per keystroke. The user's timing is the best source a handset has. */
+    private static final int BITS_PER_KEYSTROKE = 2;
+
+    private static final byte ABSORB = 0x00;
+    private static final byte RATCHET = 0x01;
+    private static final byte OUTPUT = 0x02;
+    private static final byte FINALISE = 0x03;
+
+    private final byte[] state = new byte[SHA256.DIGEST_LENGTH];
+    private int bits;
+
+    /** An empty, uncredited pool. */
+    public EntropyPool() {
+    }
+
+    /**
+     * Starts from a seed saved by a previous run, which is credited in full.
+     *
+     * A handset has very little entropy available the first time it is asked
+     * and rather more once it has been used, so a client should keep the 32
+     * bytes from {@link #exportSeed} in RMS and hand them back here at startup.
+     * That makes the expensive cold start a one-off rather than a per-launch
+     * cost. The store is app-private, so a seed that came out of a seeded pool
+     * is worth what it was worth when it was written.
+     */
+    public EntropyPool(byte[] storedSeed) {
+        addSample(storedSeed);
+        credit(REQUIRED_BITS);
+    }
+
+    /** Conservative estimate of the entropy absorbed so far, capped at the requirement. */
+    public int seededBits() {
+        return bits;
+    }
+
+    public boolean isSeeded() {
+        return bits >= REQUIRED_BITS;
+    }
+
+    /** Absorbs data without crediting it. For values an attacker might guess. */
+    public void addSample(byte[] data) {
+        SHA256 h = new SHA256();
+        h.update(state);
+        h.update(new byte[] { ABSORB });
+        h.update(data);
+        byte[] next = h.digest();
+        System.arraycopy(next, 0, state, 0, state.length);
+    }
+
+    /**
+     * Absorbs what the platform will say about itself. Deliberately uncredited:
+     * the clock and the heap sizes are all guessable, so this improves the
+     * starting position without being entropy.
+     */
+    public void addPlatformState() {
+        addSample(longToBytes(System.currentTimeMillis()));
+        addSample(longToBytes(Runtime.getRuntime().freeMemory()));
+        addSample(longToBytes(Runtime.getRuntime().totalMemory()));
+        addSample(longToBytes(System.identityHashCode(this)));
+        addSample(longToBytes(System.identityHashCode(new Object())));
+    }
+
+    /**
+     * Absorbs a keystroke and credits it.
+     *
+     * The unpredictable part is when the key was pressed rather than which key
+     * it was, so both go in but the credit is for the timing.
+     */
+    public void addKeystroke(int keyCode) {
+        addSample(longToBytes(System.currentTimeMillis()));
+        addSample(longToBytes(keyCode));
+        addSample(longToBytes(Runtime.getRuntime().freeMemory()));
+        credit(BITS_PER_KEYSTROKE);
+    }
+
+    /**
+     * Collects timing jitter, blocking for roughly one clock tick per sample.
+     *
+     * The loop counts how many iterations fit between two millisecond ticks.
+     * That count moves with scheduling, interrupts and cache state, and its low
+     * bits are the part worth having. CLDC has no nanoTime, so this
+     * millisecond-resolution version is the finest measurement available.
+     */
+    public void harvestJitter(int samples) {
+        for (int i = 0; i < samples; i++) {
+            long tick = System.currentTimeMillis();
+            long count = 0;
+            while (System.currentTimeMillis() == tick) {
+                count++;
+                // Yielding mixes the scheduler into the count rather than
+                // leaving it a pure measure of this CPU's speed.
+                if ((count & 0xff) == 0) {
+                    Thread.yield();
+                }
+            }
+            addSample(longToBytes(count));
+            addSample(longToBytes(System.currentTimeMillis()));
+            credit(BITS_PER_JITTER_SAMPLE);
+        }
+    }
+
+    /**
+     * Brings the pool up to {@link #REQUIRED_BITS}, blocking while it does.
+     *
+     * From cold this costs about a tenth of a second, so it belongs at startup
+     * rather than at connect time. From a stored seed it returns at once.
+     */
+    public void seed() {
+        addPlatformState();
+        while (!isSeeded()) {
+            harvestJitter(16);
+        }
+    }
+
+    /**
+     * Returns key material, ratcheting the state so that recovering it
+     * afterwards reveals nothing about what was returned.
+     *
+     * @throws IllegalStateException if the pool has not reached {@link #REQUIRED_BITS}
+     */
+    public byte[] nextBytes(int length) {
+        if (!isSeeded()) {
+            throw new IllegalStateException(
+                "random source has " + bits + " of " + REQUIRED_BITS + " bits; refusing to generate");
+        }
+        byte[] out = new byte[length];
+        int filled = 0;
+        while (filled < length) {
+            ratchet(RATCHET);
+
+            SHA256 h = new SHA256();
+            h.update(state);
+            h.update(new byte[] { OUTPUT });
+            byte[] block = h.digest();
+
+            int take = length - filled;
+            if (take > block.length) {
+                take = block.length;
+            }
+            System.arraycopy(block, 0, out, filled, take);
+            filled += take;
+        }
+        // Without this the state on the way out still reproduces the last block.
+        ratchet(FINALISE);
+        return out;
+    }
+
+    /**
+     * Produces 32 bytes to store for the next run. It costs the pool nothing
+     * that an ordinary generation would not, because it is one.
+     */
+    public byte[] exportSeed() {
+        return nextBytes(SHA256.DIGEST_LENGTH);
+    }
+
+    private void ratchet(byte tag) {
+        SHA256 h = new SHA256();
+        h.update(state);
+        h.update(new byte[] { tag });
+        byte[] next = h.digest();
+        System.arraycopy(next, 0, state, 0, state.length);
+    }
+
+    private void credit(int n) {
+        if (bits < REQUIRED_BITS) {
+            bits += n;
+            if (bits > REQUIRED_BITS) {
+                bits = REQUIRED_BITS;
+            }
+        }
+    }
+
+    private static byte[] longToBytes(long v) {
+        byte[] b = new byte[8];
+        for (int i = 0; i < 8; i++) {
+            b[i] = (byte) (v >>> (8 * i));
+        }
+        return b;
+    }
+}


### PR DESCRIPTION
Add a random source for key material

CLDC 1.1 has no SecureRandom, and java.util.Random is a 48-bit LCG seeded from
the clock: an attacker who knows the connection time to within a second has a
few thousand candidate seeds to search, which is not a private key. RIM's
random is a protected API, which is the thing this project exists to avoid. So
the pool is built from what the platform will actually give up.

The construction is a SHA-256 DRBG. What matters about it is the ratchet: the
state moves forward before every output block and once more before the call
returns, so a pool recovered later cannot reproduce bytes already handed out.
The test for that is the one worth keeping — a single nextBytes(64) and two
nextBytes(32) calls agree on their first block and must then diverge, which
they only do if the finalising ratchet actually happened.

The vectors are computed in Python rather than by the class under test, so they
check the construction rather than its self-consistency.

Two judgements are worth naming because no test can carry them:

The entropy estimate is a guess. Jitter samples are credited 2 bits, below what
the technique is generally thought to give, because over-crediting produces a
predictable key and nobody would ever see it happen. The gate refuses to
generate below 256 bits rather than quietly returning weak bytes.

The constructors are deterministic and platform sampling is a separate call.
A constructor that reached for the clock behind the caller's back would make
the DRBG untestable, and it buys nothing: the clock and the heap sizes are
guessable, so they are absorbed but never credited.

Also adds a stored-seed path. A handset has almost no entropy the first time it
is asked and rather more once it has been running, so exportSeed writes 32
bytes for RMS and the seed constructor credits them back — turning the cold
start into a one-off rather than a cost paid at every launch.

Closes #16.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

