### PR TITLE
Implement KEXINIT algorithm negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,26 @@ spike2/run.sh
 §2.8.2 for ChaCha20, Poly1305 and the AEAD construction, RFC 7748 §5.2 / §6.1
 for X25519, and RFC 8032 §7.1 plus negative cases for Ed25519. 28 in total.
 
-**Transport**: RFC 4251 §5 for the wire types and RFC 4253 §6 for the packet
-framing, plus the version exchange and the paths that have to reject malformed
-input. 47 in total. They run under a Turkish default locale, which is the
-device's own and the setting most likely to break protocol code without raising
-an error anywhere.
+**Transport**: RFC 4251 §5 for the wire types, RFC 4253 §6 for the packet
+framing and §7.1 for algorithm negotiation, plus the version exchange and the
+paths that have to reject malformed input. 57 in total. They run under a Turkish
+default locale, which is the device's own and the setting most likely to break
+protocol code without raising an error anywhere.
+
+### Against a real server
+
+Encodings can be proved offline; a protocol cannot. A key exchange either
+convinces an OpenSSH server or it does not, so the other half of the
+verification talks to one:
+
+```sh
+spike2/against-server.sh          # defaults to the project's container
+```
+
+It is a separate script so that `run.sh` needs nothing external. The container
+still offers the 2011 algorithms as well as the modern ones, which is what
+makes it a useful test: the negotiated set is a choice rather than the only
+thing on the table.
 
 ## Measured on the device
 
@@ -127,7 +142,9 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] X25519 key agreement
 - [x] Ed25519 signature verification, and SHA-512
 - [x] SSH transport: version exchange and the binary packet protocol
-- [ ] KEXINIT algorithm negotiation, and the key exchange
+- [x] A random source for key material
+- [x] KEXINIT algorithm negotiation
+- [ ] `curve25519-sha256` key exchange and key derivation
 - [ ] `chacha20-poly1305@openssh.com` packet layer
 - [ ] User authentication
 - [ ] Channels, `pty-req`, shell

--- a/spike2/against-server.sh
+++ b/spike2/against-server.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run the half of the verification that needs a real OpenSSH server.
+#
+# Kept apart from run.sh so that the offline vectors stay runnable with no
+# external anything. This one needs a server; by default the container the
+# project keeps for the purpose.
+#
+#   spike2/against-server.sh [host] [port]
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-2222}"
+
+if [ ! -d classes ]; then
+    echo "no classes yet — run spike2/run.sh first" >&2
+    exit 1
+fi
+
+if ! nc -z "$HOST" "$PORT" 2>/dev/null; then
+    echo "nothing listening on $HOST:$PORT" >&2
+    echo "the project's test server is a container: docker start bbssh" >&2
+    exit 1
+fi
+
+echo "==> compiling server tests (host JDK)"
+javac -nowarn -cp classes -d classes src/ServerTests.java
+
+echo "==> running against $HOST:$PORT"
+java -cp classes ServerTests "$HOST" "$PORT"

--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -1,0 +1,120 @@
+import berryssh.crypto.EntropyPool;
+import berryssh.protocol.KexInit;
+import berryssh.protocol.Message;
+import berryssh.protocol.Negotiation;
+import berryssh.protocol.Transport;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+
+/**
+ * The half of the verification that needs a real OpenSSH server.
+ *
+ * The offline vectors prove the encodings; only a real server proves the
+ * protocol. Several of these issues have no meaningful self-test — a key
+ * exchange either convinces an OpenSSH server or it does not.
+ *
+ * This runs against the container the project keeps for the purpose (see the
+ * README), reached over a plain socket. It is host-only: `java.net` does not
+ * exist in CLDC, where the same streams come from
+ * `Connector.open("socket://host:port")`. Everything under test takes streams
+ * rather than a socket precisely so that this substitution is the only
+ * difference between here and the device.
+ */
+public class ServerTests {
+
+    private static String host = "127.0.0.1";
+    private static int port = 2222;
+
+    private static int passed;
+    private static int failed;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length >= 1) {
+            host = args[0];
+        }
+        if (args.length >= 2) {
+            port = Integer.parseInt(args[1]);
+        }
+
+        System.out.println("  ..    against " + host + ":" + port);
+        negotiatesWithRealServer();
+
+        System.out.println();
+        System.out.println(passed + " passed, " + failed + " failed");
+        if (failed > 0) {
+            System.exit(1);
+        }
+    }
+
+    /**
+     * RFC 4253 sections 4.2 and 7.1 against a server that did not read our
+     * code: the identification strings have to be mutually acceptable and the
+     * negotiated set has to be the modern one, on a server that also still
+     * offers the 2011 algorithms this project exists to avoid.
+     */
+    private static void negotiatesWithRealServer() throws Exception {
+        Socket socket = new Socket(host, port);
+        try {
+            socket.setSoTimeout(10000);
+            InputStream in = socket.getInputStream();
+            OutputStream out = socket.getOutputStream();
+
+            Transport transport = new Transport(in, out);
+            transport.exchangeVersions();
+            checkTrue("the server accepts our identification and returns its own",
+                transport.serverVersion() != null
+                    && transport.serverVersion().startsWith("SSH-2.0-"));
+            System.out.println("        server is " + transport.serverVersion());
+
+            EntropyPool random = new EntropyPool();
+            random.seed();
+            KexInit ours = KexInit.client(random);
+            transport.writePacket(ours.payload());
+
+            byte[] reply = transport.readPacket();
+            checkTrue("the server answers KEXINIT with KEXINIT",
+                (reply[0] & 0xff) == Message.KEXINIT);
+
+            KexInit theirs = KexInit.parse(reply);
+            Negotiation negotiated = Negotiation.between(ours, theirs);
+
+            checkTrue("negotiated curve25519-sha256",
+                "curve25519-sha256".equals(negotiated.kex()));
+            checkTrue("negotiated ssh-ed25519",
+                "ssh-ed25519".equals(negotiated.hostKey()));
+            checkTrue("negotiated chacha20-poly1305@openssh.com both ways",
+                "chacha20-poly1305@openssh.com".equals(negotiated.cipherClientToServer())
+                    && "chacha20-poly1305@openssh.com".equals(negotiated.cipherServerToClient()));
+            checkTrue("negotiated no compression",
+                "none".equals(negotiated.compressionClientToServer())
+                    && "none".equals(negotiated.compressionServerToClient()));
+
+            // The container deliberately still offers the 2011 algorithms, so
+            // this confirms the modern set was a choice rather than the only
+            // thing on the table.
+            boolean serverStillOffersLegacy = false;
+            for (int i = 0; i < theirs.kexAlgorithms().length; i++) {
+                if ("diffie-hellman-group14-sha1".equals(theirs.kexAlgorithms()[i])) {
+                    serverStillOffersLegacy = true;
+                }
+            }
+            checkTrue("the server also offered the legacy key exchange, and we did not take it",
+                serverStillOffersLegacy);
+        } finally {
+            socket.close();
+        }
+    }
+
+    private static void checkTrue(String name, boolean condition) {
+        if (condition) {
+            passed++;
+            System.out.println("  PASS  " + name);
+        } else {
+            failed++;
+            System.out.println("  FAIL  " + name);
+        }
+    }
+}

--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -1,4 +1,6 @@
 import berryssh.protocol.Ascii;
+import berryssh.protocol.KexInit;
+import berryssh.protocol.Negotiation;
 import berryssh.protocol.SshException;
 import berryssh.protocol.Transport;
 import berryssh.protocol.WireReader;
@@ -42,6 +44,8 @@ public class TransportTests {
         packetFraming();
         versionExchange();
         malformedInput();
+        kexInitEncoding();
+        negotiationRules();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -309,6 +313,137 @@ public class TransportTests {
             () -> new WireReader(hex("7fffffff00")).readString());
         checkRejected("a negative mpint is refused",
             () -> new WireReader(hex("00000002edcc")).readMpint());
+    }
+
+    /** The payload is hashed byte for byte during the key exchange, so it is pinned here. */
+    private static void kexInitEncoding() {
+        byte[] cookie = new byte[16];
+        for (int i = 0; i < 16; i++) {
+            cookie[i] = (byte) i;
+        }
+        check("KEXINIT payload",
+            KexInit.clientWithCookie(cookie).payload(),
+            "14000102030405060708090a0b0c0d0e0f"
+                + "0000002e637572766532353531392d7368613235362c"
+                + "637572766532353531392d736861323536406c69627373682e6f7267"
+                + "0000000b7373682d65643235353139"
+                + "0000001d63686163686132302d706f6c7931333035406f70656e7373682e636f6d"
+                + "0000001d63686163686132302d706f6c7931333035406f70656e7373682e636f6d"
+                + "0000000d686d61632d736861322d323536"
+                + "0000000d686d61632d736861322d323536"
+                + "000000046e6f6e65000000046e6f6e65"
+                + "0000000000000000"
+                + "00"
+                + "00000000");
+
+        try {
+            KexInit parsed = KexInit.parse(KexInit.clientWithCookie(cookie).payload());
+            checkTrue("KEXINIT parses back to the lists it was built from",
+                parsed.kexAlgorithms().length == 2
+                    && "curve25519-sha256".equals(parsed.kexAlgorithms()[0])
+                    && "curve25519-sha256@libssh.org".equals(parsed.kexAlgorithms()[1])
+                    && "ssh-ed25519".equals(parsed.hostKeyAlgorithms()[0])
+                    && "chacha20-poly1305@openssh.com".equals(parsed.ciphersServerToClient()[0])
+                    && "none".equals(parsed.compressionClientToServer()[0])
+                    && !parsed.firstKexPacketFollows());
+        } catch (IOException e) {
+            fail("KEXINIT round trip threw " + e);
+        }
+
+        checkRejected("a payload that is not a KEXINIT is refused",
+            () -> KexInit.parse(hex("15000102030405060708090a0b0c0d0e0f")));
+    }
+
+    private static void negotiationRules() {
+        try {
+            // Our order decides, not the server's. The server here prefers the
+            // libssh name; we prefer the standardised one, so ours wins.
+            Negotiation n = Negotiation.between(clientKexInit(), serverKexInit(
+                new String[] { "curve25519-sha256@libssh.org", "curve25519-sha256" },
+                new String[] { "rsa-sha2-512", "ssh-ed25519" },
+                new String[] { "aes128-ctr", "chacha20-poly1305@openssh.com" },
+                false));
+            checkTrue("negotiation follows the client's preference order",
+                "curve25519-sha256".equals(n.kex())
+                    && "ssh-ed25519".equals(n.hostKey())
+                    && "chacha20-poly1305@openssh.com".equals(n.cipherClientToServer())
+                    && "chacha20-poly1305@openssh.com".equals(n.cipherServerToClient())
+                    && "none".equals(n.compressionServerToClient()));
+            checkTrue("nothing is discarded when the server did not guess",
+                !n.discardGuessedPacket());
+
+            // A server that guesses correctly: its first preferences match what
+            // was negotiated, so the packet it sent ahead is valid.
+            Negotiation right = Negotiation.between(clientKexInit(), serverKexInit(
+                new String[] { "curve25519-sha256" },
+                new String[] { "ssh-ed25519" },
+                new String[] { "chacha20-poly1305@openssh.com" },
+                true));
+            checkTrue("a correct guess is kept", !right.discardGuessedPacket());
+
+            // A server that guesses wrongly: its first kex is not the negotiated
+            // one, so the packet it sent ahead has to be read and dropped, or
+            // everything after it is one message out of step.
+            Negotiation wrong = Negotiation.between(clientKexInit(), serverKexInit(
+                new String[] { "curve25519-sha256@libssh.org", "curve25519-sha256" },
+                new String[] { "ssh-ed25519" },
+                new String[] { "chacha20-poly1305@openssh.com" },
+                true));
+            checkTrue("a wrong guess marks the next packet for discard",
+                wrong.discardGuessedPacket());
+        } catch (IOException e) {
+            fail("negotiation threw " + e);
+        }
+
+        checkRejected("no key exchange in common is refused",
+            () -> Negotiation.between(clientKexInit(), serverKexInit(
+                new String[] { "diffie-hellman-group14-sha1" },
+                new String[] { "ssh-ed25519" },
+                new String[] { "chacha20-poly1305@openssh.com" },
+                false)));
+
+        checkRejected("no host key algorithm in common is refused",
+            () -> Negotiation.between(clientKexInit(), serverKexInit(
+                new String[] { "curve25519-sha256" },
+                new String[] { "ssh-rsa", "ecdsa-sha2-nistp256" },
+                new String[] { "chacha20-poly1305@openssh.com" },
+                false)));
+
+        // Refusing this is what keeps the packet layer authenticated: an
+        // agreement on a non-AEAD cipher would need a separate MAC we do not have.
+        checkRejected("a cipher with no AEAD is refused",
+            () -> Negotiation.between(clientKexInit(), serverKexInit(
+                new String[] { "curve25519-sha256" },
+                new String[] { "ssh-ed25519" },
+                new String[] { "aes128-ctr" },
+                false)));
+    }
+
+    private static KexInit clientKexInit() {
+        return KexInit.clientWithCookie(new byte[16]);
+    }
+
+    /** Builds a server KEXINIT with arbitrary lists, by way of the wire format. */
+    private static KexInit serverKexInit(String[] kex, String[] hostKey, String[] ciphers,
+                                         boolean guessing) throws IOException {
+        String[] macs = { "hmac-sha2-256", "hmac-sha1" };
+        String[] compression = { "none", "zlib@openssh.com" };
+        WireWriter w = new WireWriter(512);
+        w.writeByte(20);
+        w.writeRaw(new byte[16]);
+        w.writeNameList(kex);
+        w.writeNameList(hostKey);
+        w.writeNameList(ciphers);
+        w.writeNameList(ciphers);
+        w.writeNameList(macs);
+        w.writeNameList(macs);
+        w.writeNameList(compression);
+        w.writeNameList(compression);
+        w.writeNameList(new String[0]);
+        w.writeNameList(new String[0]);
+        w.writeBoolean(guessing);
+        w.writeUint32(0);
+        return KexInit.parse(w.toByteArray());
     }
 
     private static Transport transportOver(String ascii) {

--- a/ssh/src/berryssh/protocol/KexInit.java
+++ b/ssh/src/berryssh/protocol/KexInit.java
@@ -1,0 +1,188 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+import berryssh.crypto.EntropyPool;
+
+/**
+ * SSH_MSG_KEXINIT, in both directions (RFC 4253 section 7.1).
+ *
+ * The whole payload is kept rather than just the parsed lists, because both
+ * sides' KEXINIT payloads go into the exchange hash byte for byte. Rebuilding
+ * one later to hash it would risk re-encoding it differently from what went on
+ * the wire, and the failure would show up as a signature that does not verify,
+ * with nothing to point at.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class KexInit {
+
+    /**
+     * What we offer. Each list is in preference order, and the order is the
+     * negotiation: the first entry that the server also names wins.
+     *
+     * The two curve25519 names are the same algorithm. The @libssh.org one is
+     * what the method was called before RFC 8731 standardised it, and servers
+     * of the target era answer to that name only.
+     */
+    public static final String[] KEX_ALGORITHMS = {
+        "curve25519-sha256",
+        "curve25519-sha256@libssh.org"
+    };
+
+    public static final String[] HOST_KEY_ALGORITHMS = {
+        "ssh-ed25519"
+    };
+
+    public static final String[] CIPHERS = {
+        "chacha20-poly1305@openssh.com"
+    };
+
+    /**
+     * The MAC lists are sent because RFC 4253 requires the fields, and are then
+     * unused: chacha20-poly1305 is an AEAD, so it authenticates the packet
+     * itself and RFC 4253's separate MAC does not apply. A name is offered
+     * anyway so the negotiation is well defined in every category rather than
+     * relying on the server to skip one — and since the only cipher offered is
+     * the AEAD, a MAC can never actually come into play. {@link Negotiation}
+     * asserts that.
+     */
+    public static final String[] MACS = {
+        "hmac-sha2-256"
+    };
+
+    public static final String[] COMPRESSION = {
+        "none"
+    };
+
+    private static final String[] NO_LANGUAGES = {};
+
+    private static final int COOKIE_LENGTH = 16;
+
+    private final byte[] payload;
+
+    private final String[] kexAlgorithms;
+    private final String[] hostKeyAlgorithms;
+    private final String[] ciphersClientToServer;
+    private final String[] ciphersServerToClient;
+    private final String[] macsClientToServer;
+    private final String[] macsServerToClient;
+    private final String[] compressionClientToServer;
+    private final String[] compressionServerToClient;
+    private final boolean firstKexPacketFollows;
+
+    private KexInit(byte[] payload, String[] kexAlgorithms, String[] hostKeyAlgorithms,
+                    String[] ciphersClientToServer, String[] ciphersServerToClient,
+                    String[] macsClientToServer, String[] macsServerToClient,
+                    String[] compressionClientToServer, String[] compressionServerToClient,
+                    boolean firstKexPacketFollows) {
+        this.payload = payload;
+        this.kexAlgorithms = kexAlgorithms;
+        this.hostKeyAlgorithms = hostKeyAlgorithms;
+        this.ciphersClientToServer = ciphersClientToServer;
+        this.ciphersServerToClient = ciphersServerToClient;
+        this.macsClientToServer = macsClientToServer;
+        this.macsServerToClient = macsServerToClient;
+        this.compressionClientToServer = compressionClientToServer;
+        this.compressionServerToClient = compressionServerToClient;
+        this.firstKexPacketFollows = firstKexPacketFollows;
+    }
+
+    /** Builds ours. The cookie is what stops either side alone from steering the exchange hash. */
+    public static KexInit client(EntropyPool random) {
+        return clientWithCookie(random.nextBytes(COOKIE_LENGTH));
+    }
+
+    /**
+     * Builds ours with a caller-supplied cookie, so a test can pin the exact
+     * bytes. Named awkwardly because that is the only good reason to call it:
+     * a predictable cookie lets either side steer the exchange hash.
+     */
+    public static KexInit clientWithCookie(byte[] cookie) {
+        WireWriter w = new WireWriter(512);
+        w.writeByte(Message.KEXINIT);
+        w.writeRaw(cookie, 0, COOKIE_LENGTH);
+        w.writeNameList(KEX_ALGORITHMS);
+        w.writeNameList(HOST_KEY_ALGORITHMS);
+        w.writeNameList(CIPHERS);
+        w.writeNameList(CIPHERS);
+        w.writeNameList(MACS);
+        w.writeNameList(MACS);
+        w.writeNameList(COMPRESSION);
+        w.writeNameList(COMPRESSION);
+        w.writeNameList(NO_LANGUAGES);
+        w.writeNameList(NO_LANGUAGES);
+        w.writeBoolean(false);
+        w.writeUint32(0);
+
+        return new KexInit(w.toByteArray(),
+            KEX_ALGORITHMS, HOST_KEY_ALGORITHMS, CIPHERS, CIPHERS,
+            MACS, MACS, COMPRESSION, COMPRESSION, false);
+    }
+
+    public static KexInit parse(byte[] payload) throws IOException {
+        WireReader r = new WireReader(payload);
+        int type = r.readByte();
+        if (type != Message.KEXINIT) {
+            throw new SshException("expected KEXINIT, got " + Message.name(type));
+        }
+        r.readRaw(COOKIE_LENGTH);
+
+        String[] kex = r.readNameList();
+        String[] hostKey = r.readNameList();
+        String[] cipherCtoS = r.readNameList();
+        String[] cipherStoC = r.readNameList();
+        String[] macCtoS = r.readNameList();
+        String[] macStoC = r.readNameList();
+        String[] compCtoS = r.readNameList();
+        String[] compStoC = r.readNameList();
+        r.readNameList();
+        r.readNameList();
+        boolean guessing = r.readBoolean();
+        r.readUint32();
+
+        return new KexInit(payload, kex, hostKey, cipherCtoS, cipherStoC,
+            macCtoS, macStoC, compCtoS, compStoC, guessing);
+    }
+
+    /** The payload exactly as it went on the wire, for the exchange hash. */
+    public byte[] payload() {
+        return payload;
+    }
+
+    public String[] kexAlgorithms() {
+        return kexAlgorithms;
+    }
+
+    public String[] hostKeyAlgorithms() {
+        return hostKeyAlgorithms;
+    }
+
+    public String[] ciphersClientToServer() {
+        return ciphersClientToServer;
+    }
+
+    public String[] ciphersServerToClient() {
+        return ciphersServerToClient;
+    }
+
+    public String[] macsClientToServer() {
+        return macsClientToServer;
+    }
+
+    public String[] macsServerToClient() {
+        return macsServerToClient;
+    }
+
+    public String[] compressionClientToServer() {
+        return compressionClientToServer;
+    }
+
+    public String[] compressionServerToClient() {
+        return compressionServerToClient;
+    }
+
+    public boolean firstKexPacketFollows() {
+        return firstKexPacketFollows;
+    }
+}

--- a/ssh/src/berryssh/protocol/Message.java
+++ b/ssh/src/berryssh/protocol/Message.java
@@ -1,0 +1,92 @@
+package berryssh.protocol;
+
+/**
+ * SSH message numbers.
+ *
+ * The ranges matter as much as the values: 1-19 is the transport layer, 20-29
+ * is algorithm negotiation, 30-49 is whatever the negotiated key exchange
+ * method wants and so is only meaningful in context, 50-79 is user
+ * authentication and 80-127 is the connection protocol. A number from a range
+ * that is not currently in play is a protocol error rather than something to
+ * interpret.
+ */
+public final class Message {
+
+    private Message() {
+    }
+
+    public static final int DISCONNECT = 1;
+    public static final int IGNORE = 2;
+    public static final int UNIMPLEMENTED = 3;
+    public static final int DEBUG = 4;
+    public static final int SERVICE_REQUEST = 5;
+    public static final int SERVICE_ACCEPT = 6;
+    public static final int EXT_INFO = 7;
+
+    public static final int KEXINIT = 20;
+    public static final int NEWKEYS = 21;
+
+    /** Numbered per key exchange method; these are RFC 5656 / RFC 8731 ECDH. */
+    public static final int KEX_ECDH_INIT = 30;
+    public static final int KEX_ECDH_REPLY = 31;
+
+    public static final int USERAUTH_REQUEST = 50;
+    public static final int USERAUTH_FAILURE = 51;
+    public static final int USERAUTH_SUCCESS = 52;
+    public static final int USERAUTH_BANNER = 53;
+    /** Also 60 in the publickey method, where it means PK_OK. Context decides. */
+    public static final int USERAUTH_PK_OK = 60;
+
+    public static final int GLOBAL_REQUEST = 80;
+    public static final int REQUEST_SUCCESS = 81;
+    public static final int REQUEST_FAILURE = 82;
+    public static final int CHANNEL_OPEN = 90;
+    public static final int CHANNEL_OPEN_CONFIRMATION = 91;
+    public static final int CHANNEL_OPEN_FAILURE = 92;
+    public static final int CHANNEL_WINDOW_ADJUST = 93;
+    public static final int CHANNEL_DATA = 94;
+    public static final int CHANNEL_EXTENDED_DATA = 95;
+    public static final int CHANNEL_EOF = 96;
+    public static final int CHANNEL_CLOSE = 97;
+    public static final int CHANNEL_REQUEST = 98;
+    public static final int CHANNEL_SUCCESS = 99;
+    public static final int CHANNEL_FAILURE = 100;
+
+    /** RFC 4254 section 5.2: extended data of this type is stderr. */
+    public static final int EXTENDED_DATA_STDERR = 1;
+
+    public static String name(int type) {
+        switch (type) {
+            case DISCONNECT: return "DISCONNECT";
+            case IGNORE: return "IGNORE";
+            case UNIMPLEMENTED: return "UNIMPLEMENTED";
+            case DEBUG: return "DEBUG";
+            case SERVICE_REQUEST: return "SERVICE_REQUEST";
+            case SERVICE_ACCEPT: return "SERVICE_ACCEPT";
+            case EXT_INFO: return "EXT_INFO";
+            case KEXINIT: return "KEXINIT";
+            case NEWKEYS: return "NEWKEYS";
+            case KEX_ECDH_INIT: return "KEX_ECDH_INIT";
+            case KEX_ECDH_REPLY: return "KEX_ECDH_REPLY";
+            case USERAUTH_REQUEST: return "USERAUTH_REQUEST";
+            case USERAUTH_FAILURE: return "USERAUTH_FAILURE";
+            case USERAUTH_SUCCESS: return "USERAUTH_SUCCESS";
+            case USERAUTH_BANNER: return "USERAUTH_BANNER";
+            case GLOBAL_REQUEST: return "GLOBAL_REQUEST";
+            case REQUEST_SUCCESS: return "REQUEST_SUCCESS";
+            case REQUEST_FAILURE: return "REQUEST_FAILURE";
+            case CHANNEL_OPEN: return "CHANNEL_OPEN";
+            case CHANNEL_OPEN_CONFIRMATION: return "CHANNEL_OPEN_CONFIRMATION";
+            case CHANNEL_OPEN_FAILURE: return "CHANNEL_OPEN_FAILURE";
+            case CHANNEL_WINDOW_ADJUST: return "CHANNEL_WINDOW_ADJUST";
+            case CHANNEL_DATA: return "CHANNEL_DATA";
+            case CHANNEL_EXTENDED_DATA: return "CHANNEL_EXTENDED_DATA";
+            case CHANNEL_EOF: return "CHANNEL_EOF";
+            case CHANNEL_CLOSE: return "CHANNEL_CLOSE";
+            case CHANNEL_REQUEST: return "CHANNEL_REQUEST";
+            case CHANNEL_SUCCESS: return "CHANNEL_SUCCESS";
+            case CHANNEL_FAILURE: return "CHANNEL_FAILURE";
+            default: return "message " + type;
+        }
+    }
+}

--- a/ssh/src/berryssh/protocol/Negotiation.java
+++ b/ssh/src/berryssh/protocol/Negotiation.java
@@ -1,0 +1,133 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+/**
+ * The outcome of RFC 4253 section 7.1 algorithm negotiation.
+ *
+ * The rule is one-sided on purpose: the client's list is walked in order and
+ * the first name the server also offers wins, so preference is entirely ours
+ * and a server cannot talk us down to something we like less by ordering its
+ * own list cleverly.
+ *
+ * Every comparison is String.equals, which is code-point equality. A
+ * case-insensitive match would be a bug on the target device, where the locale
+ * is Turkish — see {@link Ascii}.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Negotiation {
+
+    private static final String AEAD_CIPHER = "chacha20-poly1305@openssh.com";
+
+    private final String kex;
+    private final String hostKey;
+    private final String cipherClientToServer;
+    private final String cipherServerToClient;
+    private final String compressionClientToServer;
+    private final String compressionServerToClient;
+    private final boolean discardGuessedPacket;
+
+    private Negotiation(String kex, String hostKey,
+                        String cipherClientToServer, String cipherServerToClient,
+                        String compressionClientToServer, String compressionServerToClient,
+                        boolean discardGuessedPacket) {
+        this.kex = kex;
+        this.hostKey = hostKey;
+        this.cipherClientToServer = cipherClientToServer;
+        this.cipherServerToClient = cipherServerToClient;
+        this.compressionClientToServer = compressionClientToServer;
+        this.compressionServerToClient = compressionServerToClient;
+        this.discardGuessedPacket = discardGuessedPacket;
+    }
+
+    public static Negotiation between(KexInit client, KexInit server) throws IOException {
+        String kex = choose("key exchange", client.kexAlgorithms(), server.kexAlgorithms());
+        String hostKey = choose("host key", client.hostKeyAlgorithms(), server.hostKeyAlgorithms());
+        String cipherOut = choose("cipher client to server",
+            client.ciphersClientToServer(), server.ciphersClientToServer());
+        String cipherIn = choose("cipher server to client",
+            client.ciphersServerToClient(), server.ciphersServerToClient());
+        String compressOut = choose("compression client to server",
+            client.compressionClientToServer(), server.compressionClientToServer());
+        String compressIn = choose("compression server to client",
+            client.compressionServerToClient(), server.compressionServerToClient());
+
+        // The MAC lists are negotiated by the RFC but cannot matter here: the
+        // only cipher offered is an AEAD, which carries its own tag. If this
+        // ever fails, a non-AEAD cipher reached the offer list and the packet
+        // layer would silently stop authenticating anything.
+        if (!AEAD_CIPHER.equals(cipherOut) || !AEAD_CIPHER.equals(cipherIn)) {
+            throw new SshException("negotiated a cipher with no AEAD: "
+                + cipherOut + " / " + cipherIn);
+        }
+
+        // RFC 4253 section 7.1: a guessed first packet that turns out not to
+        // match the negotiated algorithms has to be read and thrown away, or
+        // every packet after it is interpreted one message out of step.
+        boolean discard = server.firstKexPacketFollows()
+            && (server.kexAlgorithms().length == 0
+                || server.hostKeyAlgorithms().length == 0
+                || !server.kexAlgorithms()[0].equals(kex)
+                || !server.hostKeyAlgorithms()[0].equals(hostKey));
+
+        return new Negotiation(kex, hostKey, cipherOut, cipherIn,
+            compressOut, compressIn, discard);
+    }
+
+    private static String choose(String category, String[] ours, String[] theirs)
+            throws IOException {
+        for (int i = 0; i < ours.length; i++) {
+            for (int j = 0; j < theirs.length; j++) {
+                if (ours[i].equals(theirs[j])) {
+                    return ours[i];
+                }
+            }
+        }
+        throw new SshException("no " + category + " in common; we offer "
+            + join(ours) + ", the server offers " + join(theirs));
+    }
+
+    private static String join(String[] names) {
+        if (names.length == 0) {
+            return "(nothing)";
+        }
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < names.length; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(names[i]);
+        }
+        return sb.toString();
+    }
+
+    public String kex() {
+        return kex;
+    }
+
+    public String hostKey() {
+        return hostKey;
+    }
+
+    public String cipherClientToServer() {
+        return cipherClientToServer;
+    }
+
+    public String cipherServerToClient() {
+        return cipherServerToClient;
+    }
+
+    public String compressionClientToServer() {
+        return compressionClientToServer;
+    }
+
+    public String compressionServerToClient() {
+        return compressionServerToClient;
+    }
+
+    /** True when the server guessed the key exchange wrongly and its next packet is void. */
+    public boolean discardGuessedPacket() {
+        return discardGuessedPacket;
+    }
+}


### PR DESCRIPTION
Implement KEXINIT algorithm negotiation

RFC 4253 section 7.1. We offer curve25519-sha256, ssh-ed25519 and
chacha20-poly1305@openssh.com, and nothing else.

The negotiation rule is deliberately one-sided: the client's list is walked in
order and the first name the server also offers wins. Preference is entirely
ours, so a server cannot order its own list cleverly and talk us down to
something we like less. Offering exactly one cipher makes that concrete.

Three things here are less obvious than they look.

The whole KEXINIT payload is kept rather than the parsed lists. Both sides'
payloads go into the exchange hash byte for byte, and rebuilding one later to
hash it risks re-encoding it differently from what went on the wire — which
surfaces as a signature that will not verify, with nothing to point at. The
payload encoding is pinned to a vector computed outside the class for the same
reason.

The MAC lists are sent and then ignored. RFC 4253 requires the fields, but
chacha20-poly1305 is an AEAD and carries its own tag, so a MAC cannot apply. A
name is offered anyway so negotiation is well defined in every category, and
because the only cipher offered is the AEAD, the negotiated MAC can never come
into play. Negotiation asserts the cipher is that AEAD and refuses otherwise:
agreeing on a non-AEAD cipher would leave the packet layer authenticating
nothing at all.

A wrong first-packet guess has to be read and dropped. Servers essentially
never guess, but if one does and guesses wrongly, silently ignoring the case
puts every subsequent packet one message out of step — which would present as
an unrelated parse failure much later.

Verified against the real thing. spike2/against-server.sh talks to an OpenSSH
9.2p1 that still offers the 2011 algorithms alongside the modern ones, so the
negotiated set being curve25519-sha256 / ssh-ed25519 / chacha20-poly1305 is a
choice rather than the only thing available. Encodings can be proved offline; a
protocol cannot, so this is kept as a separate script that needs a server while
run.sh stays free of external dependencies.

Closes #4.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

