### PR TITLE
Implement the curve25519-sha256 key exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,16 @@ spike2/run.sh
 
 **Crypto**: FIPS 180-4 for SHA-256 and SHA-512, RFC 8439 §2.4.2 / §2.5.2 /
 §2.8.2 for ChaCha20, Poly1305 and the AEAD construction, RFC 7748 §5.2 / §6.1
-for X25519, and RFC 8032 §7.1 plus negative cases for Ed25519. 28 in total.
+for X25519, and RFC 8032 §7.1 plus negative cases for Ed25519, and the DRBG
+against vectors computed outside it. 38 in total.
 
 **Transport**: RFC 4251 §5 for the wire types, RFC 4253 §6 for the packet
-framing and §7.1 for algorithm negotiation, plus the version exchange and the
-paths that have to reject malformed input. 57 in total. They run under a Turkish
-default locale, which is the device's own and the setting most likely to break
-protocol code without raising an error anywhere.
+framing and §7.1 for algorithm negotiation, RFC 8731 §3 for the exchange hash
+and RFC 4253 §7.2 for key derivation, plus base64, host key parsing, the
+version exchange and the paths that have to reject malformed input. 74 in
+total. They run under a Turkish default locale, which is the device's own and
+the setting most likely to break protocol code without raising an error
+anywhere.
 
 ### Against a real server
 
@@ -144,7 +147,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] SSH transport: version exchange and the binary packet protocol
 - [x] A random source for key material
 - [x] KEXINIT algorithm negotiation
-- [ ] `curve25519-sha256` key exchange and key derivation
+- [x] `curve25519-sha256` key exchange, host key check and key derivation
 - [ ] `chacha20-poly1305@openssh.com` packet layer
 - [ ] User authentication
 - [ ] Channels, `pty-req`, shell

--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -1,26 +1,25 @@
 import berryssh.crypto.EntropyPool;
+import berryssh.protocol.HostKey;
 import berryssh.protocol.KexInit;
+import berryssh.protocol.KeyExchange;
 import berryssh.protocol.Message;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.Transport;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.Socket;
 
 /**
  * The half of the verification that needs a real OpenSSH server.
  *
  * The offline vectors prove the encodings; only a real server proves the
- * protocol. Several of these issues have no meaningful self-test — a key
- * exchange either convinces an OpenSSH server or it does not.
+ * protocol. A key exchange either convinces OpenSSH or it does not, and if the
+ * exchange hash is wrong by one byte the only symptom is a signature that will
+ * not verify — so this is where that gets settled.
  *
- * This runs against the container the project keeps for the purpose (see the
- * README), reached over a plain socket. It is host-only: `java.net` does not
- * exist in CLDC, where the same streams come from
- * `Connector.open("socket://host:port")`. Everything under test takes streams
- * rather than a socket precisely so that this substitution is the only
+ * Host-only: `java.net` does not exist in CLDC, where the same streams come
+ * from `Connector.open("socket://host:port")`. Everything under test takes
+ * streams rather than a socket precisely so that substitution is the only
  * difference between here and the device.
  */
 public class ServerTests {
@@ -41,6 +40,7 @@ public class ServerTests {
 
         System.out.println("  ..    against " + host + ":" + port);
         negotiatesWithRealServer();
+        exchangesKeysWithRealServer();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -49,63 +49,116 @@ public class ServerTests {
         }
     }
 
+    /** A connection carried far enough to be useful, with the pieces kept. */
+    private static final class Handshake {
+        Socket socket;
+        Transport transport;
+        EntropyPool random;
+        KexInit ours;
+        KexInit theirs;
+        Negotiation negotiated;
+    }
+
+    private static Handshake upToKexInit() throws IOException {
+        Handshake h = new Handshake();
+        h.socket = new Socket(host, port);
+        h.socket.setSoTimeout(15000);
+        h.transport = new Transport(h.socket.getInputStream(), h.socket.getOutputStream());
+        h.transport.exchangeVersions();
+
+        h.random = new EntropyPool();
+        h.random.seed();
+        h.ours = KexInit.client(h.random);
+        h.transport.writePacket(h.ours.payload());
+
+        h.theirs = KexInit.parse(h.transport.readMessage());
+        h.negotiated = Negotiation.between(h.ours, h.theirs);
+        return h;
+    }
+
     /**
-     * RFC 4253 sections 4.2 and 7.1 against a server that did not read our
-     * code: the identification strings have to be mutually acceptable and the
-     * negotiated set has to be the modern one, on a server that also still
-     * offers the 2011 algorithms this project exists to avoid.
+     * RFC 4253 sections 4.2 and 7.1: the identification strings have to be
+     * mutually acceptable, and the negotiated set has to be the modern one on a
+     * server that still offers the 2011 algorithms as well.
      */
     private static void negotiatesWithRealServer() throws Exception {
-        Socket socket = new Socket(host, port);
+        Handshake h = upToKexInit();
         try {
-            socket.setSoTimeout(10000);
-            InputStream in = socket.getInputStream();
-            OutputStream out = socket.getOutputStream();
-
-            Transport transport = new Transport(in, out);
-            transport.exchangeVersions();
             checkTrue("the server accepts our identification and returns its own",
-                transport.serverVersion() != null
-                    && transport.serverVersion().startsWith("SSH-2.0-"));
-            System.out.println("        server is " + transport.serverVersion());
-
-            EntropyPool random = new EntropyPool();
-            random.seed();
-            KexInit ours = KexInit.client(random);
-            transport.writePacket(ours.payload());
-
-            byte[] reply = transport.readPacket();
-            checkTrue("the server answers KEXINIT with KEXINIT",
-                (reply[0] & 0xff) == Message.KEXINIT);
-
-            KexInit theirs = KexInit.parse(reply);
-            Negotiation negotiated = Negotiation.between(ours, theirs);
+                h.transport.serverVersion() != null
+                    && h.transport.serverVersion().startsWith("SSH-2.0-"));
+            System.out.println("        server is " + h.transport.serverVersion());
 
             checkTrue("negotiated curve25519-sha256",
-                "curve25519-sha256".equals(negotiated.kex()));
+                "curve25519-sha256".equals(h.negotiated.kex()));
             checkTrue("negotiated ssh-ed25519",
-                "ssh-ed25519".equals(negotiated.hostKey()));
+                "ssh-ed25519".equals(h.negotiated.hostKey()));
             checkTrue("negotiated chacha20-poly1305@openssh.com both ways",
-                "chacha20-poly1305@openssh.com".equals(negotiated.cipherClientToServer())
-                    && "chacha20-poly1305@openssh.com".equals(negotiated.cipherServerToClient()));
+                "chacha20-poly1305@openssh.com".equals(h.negotiated.cipherClientToServer())
+                    && "chacha20-poly1305@openssh.com".equals(h.negotiated.cipherServerToClient()));
             checkTrue("negotiated no compression",
-                "none".equals(negotiated.compressionClientToServer())
-                    && "none".equals(negotiated.compressionServerToClient()));
+                "none".equals(h.negotiated.compressionClientToServer())
+                    && "none".equals(h.negotiated.compressionServerToClient()));
 
             // The container deliberately still offers the 2011 algorithms, so
             // this confirms the modern set was a choice rather than the only
             // thing on the table.
-            boolean serverStillOffersLegacy = false;
-            for (int i = 0; i < theirs.kexAlgorithms().length; i++) {
-                if ("diffie-hellman-group14-sha1".equals(theirs.kexAlgorithms()[i])) {
-                    serverStillOffersLegacy = true;
+            boolean legacyOffered = false;
+            for (int i = 0; i < h.theirs.kexAlgorithms().length; i++) {
+                if ("diffie-hellman-group14-sha1".equals(h.theirs.kexAlgorithms()[i])) {
+                    legacyOffered = true;
                 }
             }
             checkTrue("the server also offered the legacy key exchange, and we did not take it",
-                serverStillOffersLegacy);
+                legacyOffered);
         } finally {
-            socket.close();
+            h.socket.close();
         }
+    }
+
+    /**
+     * RFC 8731. The server signs the exchange hash it computed; our signature
+     * check passing means our reconstruction of it agrees with the server's
+     * across all eight fields, byte for byte. There is no weaker way to pass.
+     */
+    private static void exchangesKeysWithRealServer() throws Exception {
+        Handshake h = upToKexInit();
+        try {
+            KeyExchange.Result result = KeyExchange.run(h.transport, h.ours, h.theirs, h.random);
+
+            checkTrue("the server's signature over the exchange hash verifies",
+                result.exchangeHash().length == 32);
+
+            HostKey key = result.hostKey();
+            System.out.println("        host key is " + key.fingerprint());
+            checkTrue("the host key is ssh-ed25519 and 32 bytes",
+                key.publicKey().length == 32);
+            checkTrue("the fingerprint is the one ssh-keygen prints for this server",
+                "SHA256:9tqjakW/Ia6U4hT3VgAv8EXXCxC1d3ez9mr5qjVTRZs".equals(key.fingerprint()));
+
+            // Derivation cannot be checked against the server until the cipher
+            // is in place, but its shape can: the labels must produce distinct
+            // material of the length asked for.
+            byte[] sessionId = result.exchangeHash();
+            byte[] keyOut = result.deriveKey('C', sessionId, 64);
+            byte[] keyIn = result.deriveKey('D', sessionId, 64);
+            checkTrue("derives 64 bytes per direction, and the directions differ",
+                keyOut.length == 64 && keyIn.length == 64 && !sameBytes(keyOut, keyIn));
+        } finally {
+            h.socket.close();
+        }
+    }
+
+    private static boolean sameBytes(byte[] a, byte[] b) {
+        if (a.length != b.length) {
+            return false;
+        }
+        for (int i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static void checkTrue(String name, boolean condition) {

--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -1,5 +1,8 @@
 import berryssh.protocol.Ascii;
+import berryssh.protocol.Base64;
+import berryssh.protocol.HostKey;
 import berryssh.protocol.KexInit;
+import berryssh.protocol.KeyExchange;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.SshException;
 import berryssh.protocol.Transport;
@@ -46,6 +49,9 @@ public class TransportTests {
         malformedInput();
         kexInitEncoding();
         negotiationRules();
+        base64Vectors();
+        hostKeyVectors();
+        exchangeHashVectors();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -417,6 +423,141 @@ public class TransportTests {
                 new String[] { "ssh-ed25519" },
                 new String[] { "aes128-ctr" },
                 false)));
+    }
+
+    /** RFC 4648 section 10. */
+    private static void base64Vectors() {
+        String[][] vectors = {
+            { "", "" },
+            { "f", "Zg==" },
+            { "fo", "Zm8=" },
+            { "foo", "Zm9v" },
+            { "foob", "Zm9vYg==" },
+            { "fooba", "Zm9vYmE=" },
+            { "foobar", "Zm9vYmFy" }
+        };
+        boolean encoded = true;
+        boolean decoded = true;
+        for (int i = 0; i < vectors.length; i++) {
+            if (!Base64.encode(Ascii.toBytes(vectors[i][0])).equals(vectors[i][1])) {
+                encoded = false;
+            }
+            try {
+                if (!sameBytes(Ascii.toBytes(vectors[i][0]), Base64.decode(vectors[i][1]))) {
+                    decoded = false;
+                }
+            } catch (IOException e) {
+                decoded = false;
+            }
+        }
+        checkTrue("base64 encodes the RFC 4648 vectors", encoded);
+        checkTrue("base64 decodes the RFC 4648 vectors", decoded);
+
+        checkTrue("base64 omits padding when asked",
+            "Zm9vYmE".equals(Base64.encodeUnpadded(Ascii.toBytes("fooba"))));
+
+        try {
+            checkTrue("base64 decodes without padding and across whitespace",
+                sameBytes(Ascii.toBytes("fooba"), Base64.decode("Zm9v\n YmE")));
+        } catch (IOException e) {
+            fail("unpadded decode threw " + e);
+        }
+
+        checkRejected("base64 with a character outside the alphabet is refused",
+            () -> Base64.decode("Zm9v!mE="));
+        checkRejected("base64 of an impossible length is refused",
+            () -> Base64.decode("Zm9vY"));
+    }
+
+    /**
+     * The host key of the project's test container. The fingerprint is what
+     * `ssh-keygen -lf` prints for it, so the string the handset shows can be
+     * compared against the server character for character.
+     */
+    private static void hostKeyVectors() {
+        byte[] blob = hex("0000000b7373682d6564323535313900000020"
+            + "2ff01c2270598befd06f04f4c80df20da07c5a0834d13e327bc1c5eefd9bcbbf");
+        try {
+            HostKey key = HostKey.parse(blob);
+            checkTrue("host key fingerprint matches ssh-keygen -lf",
+                "SHA256:9tqjakW/Ia6U4hT3VgAv8EXXCxC1d3ez9mr5qjVTRZs".equals(key.fingerprint()));
+            checkTrue("host key renders as a known_hosts line",
+                ("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC/wHCJwWYvv0G8E9MgN8g2gfFoINNE"
+                    + "+MnvBxe79m8u/").equals(key.toAuthorizedKey()));
+            checkTrue("host key exposes the 32 raw bytes",
+                key.publicKey().length == 32);
+        } catch (IOException e) {
+            fail("host key parse threw " + e);
+        }
+
+        checkRejected("a host key of the wrong algorithm is refused",
+            () -> HostKey.parse(hex("00000007" + "7373682d727361" + "00000001" + "05")));
+        checkRejected("an ssh-ed25519 key that is not 32 bytes is refused",
+            () -> HostKey.parse(hex("0000000b7373682d65643235353139" + "0000000401020304")));
+        checkRejected("a host key blob with trailing bytes is refused",
+            () -> HostKey.parse(hex("0000000b7373682d6564323535313900000020"
+                + "2ff01c2270598befd06f04f4c80df20da07c5a0834d13e327bc1c5eefd9bcbbf" + "ff")));
+    }
+
+    /**
+     * RFC 8731 section 3 and RFC 4253 section 7.2, against values computed
+     * outside the class. If the exchange hash is wrong by a byte the server's
+     * signature simply fails to verify, with nothing in the failure to say
+     * which of the eight fields was at fault — so it is worth pinning here.
+     */
+    private static void exchangeHashVectors() {
+        String clientVersion = "SSH-2.0-berryssh_0.1";
+        String serverVersion = "SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u10";
+        byte[] clientKexInit = counting(0, 20);
+        byte[] serverKexInit = counting(100, 40);
+        byte[] hostKeyBlob = hex("0000000b7373682d6564323535313900000020"
+            + "2ff01c2270598befd06f04f4c80df20da07c5a0834d13e327bc1c5eefd9bcbbf");
+        byte[] clientPublic = counting(0, 32);
+        byte[] serverPublic = counting(32, 32);
+        byte[] shared = hex("0f" + repeat("11", 31));
+
+        byte[] h = KeyExchange.exchangeHash(clientVersion, serverVersion,
+            clientKexInit, serverKexInit, hostKeyBlob, clientPublic, serverPublic, shared);
+        check("exchange hash", h,
+            "23f549f05c9e7da24577ec04c43b5e3f9bd9e9af8614dc5de961b6865fe54345");
+
+        // Half of all shared secrets have the top bit set and gain an mpint sign
+        // byte. Treating the secret as fixed-width would work about half the time.
+        byte[] highSecret = hex("f0" + repeat("22", 31));
+        check("exchange hash with a secret that needs an mpint sign byte",
+            KeyExchange.exchangeHash(clientVersion, serverVersion,
+                clientKexInit, serverKexInit, hostKeyBlob, clientPublic, serverPublic, highSecret),
+            "2c55820c96b5bc6f70336346ef164bd3b124d8b964826675ac090eda577cfcf1");
+
+        // 64 bytes crosses the one-hash boundary, which is the case the RFC's
+        // extension rule exists for and the one an implementation gets wrong.
+        check("derived key C, 64 bytes across the hash boundary",
+            KeyExchange.deriveKey(shared, h, 'C', h, 64),
+            "48f667892eda7f0cc12049bb69d17e412c994ac944879703452591036e99244e"
+                + "b34e3a9d0b578f6470cf0fb35166036b7d274527fd9981c1bd476efe0e142d61");
+        check("derived key D, 64 bytes",
+            KeyExchange.deriveKey(shared, h, 'D', h, 64),
+            "0697d95bd891623204b6e9db7d9e82573577e190653a7ed1d33835eb59a86874"
+                + "aab166381e714e2c7d978a59cf5bb2fb1590fe14a0b478247a271e8fb0f7a470");
+        check("derived key A, 16 bytes from one hash",
+            KeyExchange.deriveKey(shared, h, 'A', h, 16),
+            "132bce258cdfdb26edd5ce05dc891bc3");
+    }
+
+    private static byte[] counting(int from, int length) {
+        byte[] b = new byte[length];
+        for (int i = 0; i < length; i++) {
+            b[i] = (byte) (from + i);
+        }
+        return b;
+    }
+
+    private static String repeat(String s, int times) {
+        StringBuffer sb = new StringBuffer(s.length() * times);
+        for (int i = 0; i < times; i++) {
+            sb.append(s);
+        }
+        return sb.toString();
     }
 
     private static KexInit clientKexInit() {

--- a/ssh/src/berryssh/protocol/Base64.java
+++ b/ssh/src/berryssh/protocol/Base64.java
@@ -1,0 +1,107 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+/**
+ * RFC 4648 base64.
+ *
+ * CLDC 1.1 has no encoder, and SSH needs one in the places a human has to read
+ * or type a key: the SHA-256 host key fingerprint OpenSSH prints, and the
+ * `ssh-ed25519 AAAA...` line from an authorized_keys or known_hosts file.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Base64 {
+
+    private static final String ALPHABET =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    private Base64() {
+    }
+
+    /** Encodes with '=' padding. */
+    public static String encode(byte[] data) {
+        return encode(data, true);
+    }
+
+    /**
+     * Encodes without padding, which is the form OpenSSH prints fingerprints
+     * in — `SHA256:` followed by 43 characters and no trailing '='.
+     */
+    public static String encodeUnpadded(byte[] data) {
+        return encode(data, false);
+    }
+
+    private static String encode(byte[] data, boolean pad) {
+        StringBuffer sb = new StringBuffer((data.length + 2) / 3 * 4);
+        int i = 0;
+        while (i + 3 <= data.length) {
+            int v = ((data[i] & 0xff) << 16) | ((data[i + 1] & 0xff) << 8) | (data[i + 2] & 0xff);
+            sb.append(ALPHABET.charAt((v >>> 18) & 0x3f));
+            sb.append(ALPHABET.charAt((v >>> 12) & 0x3f));
+            sb.append(ALPHABET.charAt((v >>> 6) & 0x3f));
+            sb.append(ALPHABET.charAt(v & 0x3f));
+            i += 3;
+        }
+        int left = data.length - i;
+        if (left == 1) {
+            int v = (data[i] & 0xff) << 16;
+            sb.append(ALPHABET.charAt((v >>> 18) & 0x3f));
+            sb.append(ALPHABET.charAt((v >>> 12) & 0x3f));
+            if (pad) {
+                sb.append('=');
+                sb.append('=');
+            }
+        } else if (left == 2) {
+            int v = ((data[i] & 0xff) << 16) | ((data[i + 1] & 0xff) << 8);
+            sb.append(ALPHABET.charAt((v >>> 18) & 0x3f));
+            sb.append(ALPHABET.charAt((v >>> 12) & 0x3f));
+            sb.append(ALPHABET.charAt((v >>> 6) & 0x3f));
+            if (pad) {
+                sb.append('=');
+            }
+        }
+        return sb.toString();
+    }
+
+    /** Decodes, tolerating missing padding and embedded whitespace. */
+    public static byte[] decode(String text) throws IOException {
+        int[] symbols = new int[text.length()];
+        int count = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '=' || c == ' ' || c == '\r' || c == '\n' || c == '\t') {
+                continue;
+            }
+            int v = ALPHABET.indexOf(c);
+            if (v < 0) {
+                throw new SshException("not base64: '" + c + "'");
+            }
+            symbols[count++] = v;
+        }
+        if (count % 4 == 1) {
+            throw new SshException("base64 of an impossible length");
+        }
+
+        byte[] out = new byte[count * 3 / 4];
+        int o = 0;
+        int i = 0;
+        while (count - i >= 4) {
+            int v = (symbols[i] << 18) | (symbols[i + 1] << 12) | (symbols[i + 2] << 6) | symbols[i + 3];
+            out[o++] = (byte) (v >>> 16);
+            out[o++] = (byte) (v >>> 8);
+            out[o++] = (byte) v;
+            i += 4;
+        }
+        int left = count - i;
+        if (left == 2) {
+            int v = (symbols[i] << 18) | (symbols[i + 1] << 12);
+            out[o++] = (byte) (v >>> 16);
+        } else if (left == 3) {
+            int v = (symbols[i] << 18) | (symbols[i + 1] << 12) | (symbols[i + 2] << 6);
+            out[o++] = (byte) (v >>> 16);
+            out[o++] = (byte) (v >>> 8);
+        }
+        return out;
+    }
+}

--- a/ssh/src/berryssh/protocol/HostKey.java
+++ b/ssh/src/berryssh/protocol/HostKey.java
@@ -1,0 +1,99 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+import berryssh.crypto.Ed25519;
+import berryssh.crypto.SHA256;
+
+/**
+ * A server's public host key, and the signature check that is the whole
+ * security of the handshake.
+ *
+ * The key exchange proves the server holds the private half of this key. What
+ * it cannot prove is that this is the server you meant to reach — that is
+ * {@link KnownHosts}, and without it the signature check only rules out a
+ * passive eavesdropper, not somebody standing in the middle.
+ *
+ * Only `ssh-ed25519` is understood. That is the entire supported set rather
+ * than a preference: an RSA host key would need a 2048-bit modular
+ * exponentiation, which is the cost this project exists to avoid.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class HostKey {
+
+    public static final String ALGORITHM = "ssh-ed25519";
+
+    private final byte[] blob;
+    private final byte[] publicKey;
+
+    private HostKey(byte[] blob, byte[] publicKey) {
+        this.blob = blob;
+        this.publicKey = publicKey;
+    }
+
+    /**
+     * Parses the key blob as it arrives in the key exchange reply:
+     * a name, then the 32 raw bytes of the Ed25519 key.
+     */
+    public static HostKey parse(byte[] blob) throws IOException {
+        WireReader r = new WireReader(blob);
+        String algorithm = r.readAsciiString();
+        if (!ALGORITHM.equals(algorithm)) {
+            throw new SshException("host key is " + algorithm + ", not " + ALGORITHM);
+        }
+        byte[] key = r.readString();
+        if (key.length != Ed25519.PUBLIC_KEY_LENGTH) {
+            throw new SshException("ssh-ed25519 host key is " + key.length + " bytes, not 32");
+        }
+        if (r.remaining() != 0) {
+            throw new SshException("host key blob has " + r.remaining() + " trailing bytes");
+        }
+        return new HostKey(blob, key);
+    }
+
+    /** The blob exactly as it arrived. It is hashed into the exchange hash. */
+    public byte[] blob() {
+        return blob;
+    }
+
+    public byte[] publicKey() {
+        return publicKey;
+    }
+
+    /**
+     * Verifies a signature blob — a name and then the 64 signature bytes —
+     * over the given message.
+     *
+     * The algorithm name inside the signature is checked against our own
+     * constant rather than against whatever the blob claims, so a server cannot
+     * name an algorithm we do not implement and have the check skipped.
+     */
+    public boolean verify(byte[] message, byte[] signatureBlob) throws IOException {
+        WireReader r = new WireReader(signatureBlob);
+        String algorithm = r.readAsciiString();
+        if (!ALGORITHM.equals(algorithm)) {
+            throw new SshException("signature is " + algorithm + ", not " + ALGORITHM);
+        }
+        byte[] signature = r.readString();
+        if (signature.length != Ed25519.SIGNATURE_LENGTH) {
+            throw new SshException("ssh-ed25519 signature is " + signature.length + " bytes, not 64");
+        }
+        return Ed25519.verify(publicKey, message, signature);
+    }
+
+    /**
+     * The fingerprint in the form OpenSSH prints, so that what the handset
+     * shows can be compared character for character with `ssh-keygen -lf` on
+     * the server. A fingerprint in a format nobody else produces is a
+     * fingerprint nobody will check.
+     */
+    public String fingerprint() {
+        return "SHA256:" + Base64.encodeUnpadded(SHA256.hash(blob));
+    }
+
+    /** The `ssh-ed25519 AAAA...` form, as it appears in a known_hosts file. */
+    public String toAuthorizedKey() {
+        return ALGORITHM + " " + Base64.encode(blob);
+    }
+}

--- a/ssh/src/berryssh/protocol/KeyExchange.java
+++ b/ssh/src/berryssh/protocol/KeyExchange.java
@@ -1,0 +1,187 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+import berryssh.crypto.EntropyPool;
+import berryssh.crypto.SHA256;
+import berryssh.crypto.X25519;
+
+/**
+ * curve25519-sha256 key exchange (RFC 8731) and the key derivation that
+ * follows it (RFC 4253 section 7.2).
+ *
+ * The exchange hash is the load-bearing part. Both sides compute it over the
+ * same eight fields — the identification strings, both KEXINIT payloads, the
+ * host key, both ephemeral public keys and the shared secret — and the server
+ * signs it. If our reconstruction differs from the server's by a single byte,
+ * the signature does not verify and there is nothing in the failure to say
+ * which field was wrong. That is why the payloads are kept verbatim from the
+ * wire rather than rebuilt: see {@link KexInit}.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class KeyExchange {
+
+    private KeyExchange() {
+    }
+
+    /**
+     * The material the rest of the connection is built from.
+     *
+     * The shared secret is kept because rekeying derives from it, and the
+     * exchange hash because the first one becomes the session identifier and is
+     * then signed during user authentication.
+     */
+    public static final class Result {
+
+        private final byte[] exchangeHash;
+        private final byte[] sharedSecret;
+        private final HostKey hostKey;
+
+        Result(byte[] exchangeHash, byte[] sharedSecret, HostKey hostKey) {
+            this.exchangeHash = exchangeHash;
+            this.sharedSecret = sharedSecret;
+            this.hostKey = hostKey;
+        }
+
+        public byte[] exchangeHash() {
+            return exchangeHash;
+        }
+
+        public HostKey hostKey() {
+            return hostKey;
+        }
+
+        /** See {@link KeyExchange#deriveKey}. */
+        public byte[] deriveKey(char label, byte[] sessionId, int length) {
+            return KeyExchange.deriveKey(sharedSecret, exchangeHash, label, sessionId, length);
+        }
+    }
+
+    /**
+     * RFC 4253 section 7.2. The label is one of 'A' to 'F': initialisation
+     * vectors, encryption keys and MAC keys, client to server then server to
+     * client.
+     *
+     * One hash is 32 bytes and chacha20-poly1305 wants 64 per direction, so the
+     * extension applies: each further block hashes everything produced so far,
+     * which is why the blocks cannot be computed independently of one another.
+     */
+    public static byte[] deriveKey(byte[] sharedSecret, byte[] exchangeHash,
+                                   char label, byte[] sessionId, int length) {
+        byte[] secret = mpint(sharedSecret);
+
+        SHA256 h = new SHA256();
+        h.update(secret);
+        h.update(exchangeHash);
+        h.update(new byte[] { (byte) label });
+        h.update(sessionId);
+        byte[] block = h.digest();
+
+        byte[] key = new byte[length];
+        int filled = copy(block, key, 0);
+        while (filled < length) {
+            h = new SHA256();
+            h.update(secret);
+            h.update(exchangeHash);
+            h.update(key, 0, filled);
+            block = h.digest();
+            filled += copy(block, key, filled);
+        }
+        return key;
+    }
+
+    private static int copy(byte[] block, byte[] key, int at) {
+        int take = key.length - at;
+        if (take > block.length) {
+            take = block.length;
+        }
+        System.arraycopy(block, 0, key, at, take);
+        return take;
+    }
+
+    /**
+     * Runs the exchange over an established transport, after KEXINIT has been
+     * traded in both directions.
+     *
+     * On return the server has proved it holds the private half of the host key
+     * it presented. Whether that key is the right one is a separate question,
+     * and the caller must still ask it.
+     */
+    public static Result run(Transport transport, KexInit client, KexInit server,
+                             EntropyPool random) throws IOException {
+        byte[] privateKey = random.nextBytes(X25519.KEY_LENGTH);
+        X25519.clamp(privateKey);
+        byte[] clientPublic = X25519.scalarMultBase(privateKey);
+
+        WireWriter init = new WireWriter(64);
+        init.writeByte(Message.KEX_ECDH_INIT);
+        init.writeString(clientPublic);
+        transport.writePacket(init.toByteArray());
+
+        byte[] payload = transport.readMessage();
+        WireReader r = new WireReader(payload);
+        int type = r.readByte();
+        if (type != Message.KEX_ECDH_REPLY) {
+            throw new SshException("expected KEX_ECDH_REPLY, got " + Message.name(type));
+        }
+        byte[] hostKeyBlob = r.readString();
+        byte[] serverPublic = r.readString();
+        byte[] signature = r.readString();
+
+        if (serverPublic.length != X25519.KEY_LENGTH) {
+            throw new SshException("server ephemeral key is "
+                + serverPublic.length + " bytes, not 32");
+        }
+
+        byte[] shared = X25519.scalarMult(privateKey, serverPublic);
+        // RFC 7748 section 6.1: an all-zero result means the peer sent a
+        // low-order point, which forces the shared secret regardless of our
+        // private key. It is an attack, not an unlucky exchange.
+        if (X25519.isAllZero(shared)) {
+            throw new SshException("server sent a low-order point; the shared secret would be forced");
+        }
+
+        HostKey hostKey = HostKey.parse(hostKeyBlob);
+
+        byte[] exchangeHash = exchangeHash(
+            transport.clientVersion(), transport.serverVersion(),
+            client.payload(), server.payload(),
+            hostKeyBlob, clientPublic, serverPublic, shared);
+
+        if (!hostKey.verify(exchangeHash, signature)) {
+            throw new SshException("the server's signature over the exchange hash does not verify");
+        }
+
+        return new Result(exchangeHash, shared, hostKey);
+    }
+
+    /** RFC 8731 section 3. The field order is the agreement; nothing here is arbitrary. */
+    public static byte[] exchangeHash(String clientVersion, String serverVersion,
+                                      byte[] clientKexInit, byte[] serverKexInit,
+                                      byte[] hostKeyBlob, byte[] clientPublic,
+                                      byte[] serverPublic, byte[] sharedSecret) {
+        WireWriter w = new WireWriter(1024);
+        w.writeAsciiString(clientVersion);
+        w.writeAsciiString(serverVersion);
+        w.writeString(clientKexInit);
+        w.writeString(serverKexInit);
+        w.writeString(hostKeyBlob);
+        w.writeString(clientPublic);
+        w.writeString(serverPublic);
+        w.writeMpint(sharedSecret);
+        return SHA256.hash(w.toByteArray());
+    }
+
+    /**
+     * The shared secret as it appears inside a hash: an mpint, not 32 raw
+     * bytes. A secret whose leading byte happens to be below 0x80 encodes
+     * shorter, and one at or above it gains a zero byte — so roughly half of
+     * all exchanges would fail if this were treated as fixed-width.
+     */
+    private static byte[] mpint(byte[] magnitude) {
+        WireWriter w = new WireWriter(magnitude.length + 8);
+        w.writeMpint(magnitude);
+        return w.toByteArray();
+    }
+}

--- a/ssh/src/berryssh/protocol/Transport.java
+++ b/ssh/src/berryssh/protocol/Transport.java
@@ -189,6 +189,57 @@ public final class Transport {
     }
 
     /**
+     * Reads the next packet that carries something the caller should act on.
+     *
+     * IGNORE and DEBUG may arrive at any point, including in the middle of the
+     * key exchange, and are the peer's business rather than ours. Handling them
+     * here rather than at each call site means a server that sends one cannot
+     * put every state machine above this out of step — which is a fault that
+     * would present as an unrelated message-type error somewhere else entirely.
+     *
+     * DISCONNECT is turned into the exception it is. The server's own reason is
+     * far more useful than the read failure that would otherwise follow.
+     */
+    public byte[] readMessage() throws IOException {
+        for (;;) {
+            byte[] payload = readPacket();
+            if (payload.length == 0) {
+                throw new SshException("empty packet");
+            }
+            int type = payload[0] & 0xff;
+            if (type == Message.IGNORE || type == Message.DEBUG) {
+                continue;
+            }
+            if (type == Message.DISCONNECT) {
+                throw disconnectReason(payload);
+            }
+            return payload;
+        }
+    }
+
+    /** Tells the peer why we are going, then leaves. RFC 4253 section 11.1. */
+    public void writeDisconnect(int reasonCode, String description) throws IOException {
+        WireWriter w = new WireWriter(64 + description.length());
+        w.writeByte(Message.DISCONNECT);
+        w.writeUint32(reasonCode);
+        w.writeAsciiString(description);
+        w.writeAsciiString("");
+        writePacket(w.toByteArray());
+    }
+
+    private static SshException disconnectReason(byte[] payload) {
+        try {
+            WireReader r = new WireReader(payload);
+            r.readByte();
+            long code = r.readUint32();
+            String description = r.readAsciiString();
+            return new SshException("server disconnected (" + code + "): " + description);
+        } catch (IOException e) {
+            return new SshException("server disconnected, with an unreadable reason");
+        }
+    }
+
+    /**
      * Reads one CR-LF-terminated line, a byte at a time.
      *
      * Reading ahead in blocks would swallow the first packet, and CLDC has no


### PR DESCRIPTION
Implement the curve25519-sha256 key exchange

RFC 8731, plus the RFC 4253 section 7.2 key derivation and the host key
handling the exchange depends on.

The exchange hash is the load-bearing part and the hardest to debug. Both sides
compute it over the same eight fields and the server signs the result; if our
reconstruction differs by one byte the signature simply fails to verify, and
nothing in the failure says which field was wrong. Two things guard against
that. Both KEXINIT payloads are kept verbatim from the wire rather than rebuilt,
so a re-encoding cannot drift from what was hashed. And the shared secret is
encoded as an mpint rather than 32 fixed bytes — a secret with its top bit set
gains a sign byte and one with a small leading byte loses bytes, so treating it
as fixed-width would work for roughly half of all connections and fail for the
rest, which is the shape of bug that gets blamed on the server.

Verified against OpenSSH 9.2p1: the signature over the exchange hash verifies,
which is not something that can pass by accident.

A low-order point from the server is refused. It would force the shared secret
regardless of our private key, so an all-zero result is an attack rather than
an unlucky exchange.

Only ssh-ed25519 host keys are understood, and that is the supported set rather
than a preference — an RSA host key means a 2048-bit modular exponentiation,
which is the cost this project exists to avoid.

Fingerprints are the SHA-256 base64 form OpenSSH prints, checked against what
ssh-keygen -lf says for the test server's key. A fingerprint in a format
nothing else produces is one nobody will ever compare.

Also adds readMessage() to the transport. IGNORE and DEBUG may arrive at any
point, including mid-exchange; handling them once here rather than at each call
site means a server that sends one cannot put every state machine above it out
of step, which would otherwise surface as an unrelated message-type error a
long way from the cause. DISCONNECT becomes the exception it already is, so the
server's stated reason survives instead of being replaced by a read failure.

Closes #5.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

