### PR TITLE
Implement the chacha20-poly1305@openssh.com packet layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ against vectors computed outside it. 38 in total.
 **Transport**: RFC 4251 §5 for the wire types, RFC 4253 §6 for the packet
 framing and §7.1 for algorithm negotiation, RFC 8731 §3 for the exchange hash
 and RFC 4253 §7.2 for key derivation, plus base64, host key parsing, the
-version exchange and the paths that have to reject malformed input. 74 in
-total. They run under a Turkish default locale, which is the device's own and
+version exchange, the chacha20-poly1305 packet layer and the paths that have
+to reject malformed input. 85 in total. They run under a Turkish default locale, which is the device's own and
 the setting most likely to break protocol code without raising an error
 anywhere.
 
@@ -148,7 +148,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] A random source for key material
 - [x] KEXINIT algorithm negotiation
 - [x] `curve25519-sha256` key exchange, host key check and key derivation
-- [ ] `chacha20-poly1305@openssh.com` packet layer
+- [x] `chacha20-poly1305@openssh.com` packet layer, and an encrypted handshake
 - [ ] User authentication
 - [ ] Channels, `pty-req`, shell
 - [ ] Terminal emulation and UI

--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -1,4 +1,5 @@
 import berryssh.crypto.EntropyPool;
+import berryssh.protocol.Connection;
 import berryssh.protocol.HostKey;
 import berryssh.protocol.KexInit;
 import berryssh.protocol.KeyExchange;
@@ -41,6 +42,7 @@ public class ServerTests {
         System.out.println("  ..    against " + host + ":" + port);
         negotiatesWithRealServer();
         exchangesKeysWithRealServer();
+        encryptsWithRealServer();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -146,6 +148,45 @@ public class ServerTests {
                 keyOut.length == 64 && keyIn.length == 64 && !sameBytes(keyOut, keyIn));
         } finally {
             h.socket.close();
+        }
+    }
+
+    /**
+     * The full handshake through NEWKEYS, and then a packet in each direction
+     * under the negotiated cipher.
+     *
+     * A service request is the smallest thing that proves it: the server has to
+     * authenticate and decrypt what we sent, and we have to authenticate and
+     * decrypt its answer. Both directions and both keys, in one exchange. There
+     * is no way for this to pass with the key halves swapped or the padding
+     * rule wrong.
+     */
+    private static void encryptsWithRealServer() throws Exception {
+        Socket socket = new Socket(host, port);
+        try {
+            socket.setSoTimeout(15000);
+            EntropyPool random = new EntropyPool();
+            random.seed();
+            Connection connection = new Connection(
+                socket.getInputStream(), socket.getOutputStream(), random);
+
+            HostKey key = connection.handshake();
+            checkTrue("the handshake completes through NEWKEYS in both directions",
+                key != null && connection.sessionId() != null
+                    && connection.sessionId().length == 32);
+
+            connection.requestService("ssh-userauth");
+            checkTrue("an encrypted service request is accepted and its reply decrypts",
+                connection.transport().sendSequence() > 0
+                    && connection.transport().receiveSequence() > 0);
+
+            // Sequence numbers have to agree with the server's or the nonces
+            // diverge and nothing decrypts from that point on. Getting several
+            // packets past NEWKEYS is that agreement holding.
+            System.out.println("        " + connection.transport().sendSequence()
+                + " packets sent, " + connection.transport().receiveSequence() + " received");
+        } finally {
+            socket.close();
         }
     }
 

--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -3,6 +3,7 @@ import berryssh.protocol.Base64;
 import berryssh.protocol.HostKey;
 import berryssh.protocol.KexInit;
 import berryssh.protocol.KeyExchange;
+import berryssh.protocol.PacketCipher;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.SshException;
 import berryssh.protocol.Transport;
@@ -52,6 +53,8 @@ public class TransportTests {
         base64Vectors();
         hostKeyVectors();
         exchangeHashVectors();
+        packetCipherVectors();
+        encryptedFraming();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -542,6 +545,122 @@ public class TransportTests {
         check("derived key A, 16 bytes from one hash",
             KeyExchange.deriveKey(shared, h, 'A', h, 16),
             "132bce258cdfdb26edd5ce05dc891bc3");
+    }
+
+    /**
+     * chacha20-poly1305@openssh.com against a reference written from
+     * PROTOCOL.chacha20poly1305 rather than from this implementation. The two
+     * key halves are the detail worth pinning: swapping them gives a cipher
+     * that is perfectly self-consistent and cannot talk to anything.
+     */
+    private static void packetCipherVectors() {
+        byte[] key = counting(0, 64);
+        byte[] body = hex("0baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000102030405060708090a");
+
+        check("sealed packet: encrypted length, body and tag",
+            new PacketCipher(key).seal(3, body),
+            "fb1a92aa"
+                + "8befb61198e00edb22e556a0114d3ce9cd76e66d6add5e45080e036ea6bd88c8"
+                + "373ac47bfddf5152b56c3baaae5aa723");
+
+        checkTrue("the length field decrypts on its own, before anything is authenticated",
+            new PacketCipher(key).peekLength(3, hex("fb1a92aa")) == 32);
+
+        // The sequence number is the nonce, which is what makes a packet
+        // impossible to replay or reorder: its number authenticates it.
+        checkTrue("a different sequence number produces a different packet",
+            !toHex(new PacketCipher(key).seal(4, body))
+                .equals(toHex(new PacketCipher(key).seal(3, body))));
+
+        try {
+            PacketCipher cipher = new PacketCipher(key);
+            byte[] wire = cipher.seal(7, body);
+            byte[] encryptedLength = slice(wire, 0, 4);
+            byte[] encryptedBody = slice(wire, 4, wire.length - 20);
+            byte[] tag = slice(wire, wire.length - 16, 16);
+            checkTrue("a sealed packet opens back to the same body",
+                sameBytes(body, cipher.open(7, encryptedLength, encryptedBody, tag)));
+
+            checkRejected("a packet opened at the wrong sequence number is refused",
+                () -> cipher.open(8, encryptedLength, encryptedBody, tag));
+            checkRejected("a tampered tag is refused",
+                () -> cipher.open(7, encryptedLength, encryptedBody, flip(tag, 0)));
+            checkRejected("a tampered body is refused",
+                () -> cipher.open(7, encryptedLength, flip(encryptedBody, 5), tag));
+            // The tag covers the length field too, so tampering with it is
+            // caught even though it is encrypted under a separate key.
+            checkRejected("a tampered length field is refused",
+                () -> cipher.open(7, flip(encryptedLength, 0), encryptedBody, tag));
+        } catch (IOException e) {
+            fail("packet cipher round trip threw " + e);
+        }
+    }
+
+    /**
+     * The framing changes once the AEAD is in play: RFC 4253 counts the length
+     * field towards the block multiple, but chacha20-poly1305 encrypts it
+     * separately, so it is excluded. Getting this wrong produces packets a
+     * server rejects as corrupt without saying that padding is the objection.
+     */
+    private static void encryptedFraming() {
+        byte[] key = counting(64, 64);
+        boolean allRoundTripped = true;
+        boolean allAligned = true;
+
+        for (int length = 0; length <= 40; length++) {
+            byte[] payload = counting(1, length);
+            try {
+                ByteArrayOutputStream sink = new ByteArrayOutputStream();
+                Transport writer = new Transport(new ByteArrayInputStream(new byte[0]), sink);
+                writer.encryptOutgoing(new PacketCipher(key));
+                writer.writePacket(payload);
+                byte[] wire = sink.toByteArray();
+
+                // The encrypted run between the length field and the tag is
+                // what has to be a whole number of blocks.
+                int encrypted = wire.length - 4 - PacketCipher.TAG_LENGTH;
+                if (encrypted % 8 != 0 || wire.length < 16 + PacketCipher.TAG_LENGTH) {
+                    allAligned = false;
+                }
+
+                Transport reader = new Transport(new ByteArrayInputStream(wire),
+                                                 new ByteArrayOutputStream());
+                reader.decryptIncoming(new PacketCipher(key));
+                if (!sameBytes(payload, reader.readPacket())) {
+                    allRoundTripped = false;
+                }
+            } catch (IOException e) {
+                fail("encrypted framing of a " + length + "-byte payload threw " + e);
+                return;
+            }
+        }
+
+        checkTrue("encrypted packets of every payload length 0..40 are block aligned", allAligned);
+        checkTrue("encrypted packets of every payload length 0..40 round trip", allRoundTripped);
+
+        // A cipher enabled on one side only must fail rather than produce
+        // plausible nonsense, which is what a mis-ordered NEWKEYS would do.
+        checkRejected("a plaintext reader refuses an encrypted packet", () -> {
+            ByteArrayOutputStream sink = new ByteArrayOutputStream();
+            Transport writer = new Transport(new ByteArrayInputStream(new byte[0]), sink);
+            writer.encryptOutgoing(new PacketCipher(key));
+            writer.writePacket(Ascii.toBytes("this should not be readable in the clear"));
+            new Transport(new ByteArrayInputStream(sink.toByteArray()),
+                          new ByteArrayOutputStream()).readPacket();
+        });
+    }
+
+    private static byte[] slice(byte[] b, int offset, int length) {
+        byte[] out = new byte[length];
+        System.arraycopy(b, offset, out, 0, length);
+        return out;
+    }
+
+    private static byte[] flip(byte[] b, int index) {
+        byte[] out = new byte[b.length];
+        System.arraycopy(b, 0, out, 0, b.length);
+        out[index] ^= 0x01;
+        return out;
     }
 
     private static byte[] counting(int from, int length) {

--- a/ssh/src/berryssh/protocol/Connection.java
+++ b/ssh/src/berryssh/protocol/Connection.java
@@ -1,0 +1,122 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import berryssh.crypto.EntropyPool;
+
+/**
+ * An SSH connection, from the version exchange through to an encrypted channel.
+ *
+ * Deliberately built on java.io streams rather than anything from MIDP, so the
+ * whole protocol stack runs unchanged on the host against a socket and on the
+ * device against `Connector.open("socket://host:port")`. That is what lets the
+ * handshake be tested against a real OpenSSH server without a device in the
+ * loop.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Connection {
+
+    private final Transport transport;
+    private final EntropyPool random;
+
+    private byte[] sessionId;
+    private HostKey hostKey;
+
+    public Connection(InputStream in, OutputStream out, EntropyPool random) {
+        this.transport = new Transport(in, out);
+        this.random = random;
+    }
+
+    public Transport transport() {
+        return transport;
+    }
+
+    /**
+     * The exchange hash of the first key exchange. It never changes afterwards,
+     * even across a rekey, which is what makes it usable as the thing a user
+     * authentication signature is bound to.
+     */
+    public byte[] sessionId() {
+        return sessionId;
+    }
+
+    public HostKey hostKey() {
+        return hostKey;
+    }
+
+    /**
+     * Runs the handshake to the point where both directions are encrypted.
+     *
+     * The host key is returned rather than trusted. The signature check inside
+     * the key exchange proves the server holds the private half of the key it
+     * presented; it says nothing about whether that is the server the user
+     * meant to reach. The caller has to answer that separately, and until it
+     * does, this connection is protected against a passive eavesdropper only.
+     */
+    public HostKey handshake() throws IOException {
+        transport.exchangeVersions();
+
+        KexInit ours = KexInit.client(random);
+        transport.writePacket(ours.payload());
+        KexInit theirs = KexInit.parse(expect(transport.readMessage(), Message.KEXINIT));
+
+        Negotiation negotiated = Negotiation.between(ours, theirs);
+        if (negotiated.discardGuessedPacket()) {
+            // The server guessed the key exchange wrongly. Its next packet is
+            // void, and reading past it would leave everything after one
+            // message out of step.
+            transport.readMessage();
+        }
+
+        KeyExchange.Result result = KeyExchange.run(transport, ours, theirs, random);
+        hostKey = result.hostKey();
+        sessionId = result.exchangeHash();
+
+        // NEWKEYS is directional and the two halves are not simultaneous: our
+        // packets become encrypted after we send ours, the server's after it
+        // sends its own. Enabling either early reads or writes a packet with a
+        // cipher the far end is not using yet.
+        WireWriter newKeys = new WireWriter(8);
+        newKeys.writeByte(Message.NEWKEYS);
+        transport.writePacket(newKeys.toByteArray());
+        transport.encryptOutgoing(new PacketCipher(
+            result.deriveKey('C', sessionId, PacketCipher.KEY_LENGTH)));
+
+        expect(transport.readMessage(), Message.NEWKEYS);
+        transport.decryptIncoming(new PacketCipher(
+            result.deriveKey('D', sessionId, PacketCipher.KEY_LENGTH)));
+
+        return hostKey;
+    }
+
+    /**
+     * Asks the server to start a service, and waits for it to agree.
+     * RFC 4253 section 10.
+     */
+    public void requestService(String service) throws IOException {
+        WireWriter w = new WireWriter(32);
+        w.writeByte(Message.SERVICE_REQUEST);
+        w.writeAsciiString(service);
+        transport.writePacket(w.toByteArray());
+
+        byte[] reply = expect(transport.readMessage(), Message.SERVICE_ACCEPT);
+        WireReader r = new WireReader(reply);
+        r.readByte();
+        String accepted = r.readAsciiString();
+        if (!service.equals(accepted)) {
+            throw new SshException("asked for service " + service + ", got " + accepted);
+        }
+    }
+
+    static byte[] expect(byte[] payload, int type) throws IOException {
+        int actual = payload[0] & 0xff;
+        if (actual != type) {
+            throw new SshException("expected " + Message.name(type)
+                + ", got " + Message.name(actual));
+        }
+        return payload;
+    }
+}

--- a/ssh/src/berryssh/protocol/PacketCipher.java
+++ b/ssh/src/berryssh/protocol/PacketCipher.java
@@ -1,0 +1,161 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+import berryssh.crypto.ChaCha20;
+import berryssh.crypto.Poly1305;
+
+/**
+ * chacha20-poly1305@openssh.com, which is not the RFC 8439 AEAD.
+ *
+ * The difference that matters is the length field. A packet's length has to be
+ * read before the rest of the packet can be, so it cannot be inside the
+ * authenticated ciphertext — but leaving it in the clear leaks the size of
+ * every keystroke and every window update. OpenSSH's answer is a second key
+ * used for nothing else: the length is encrypted on its own with K_1, and the
+ * Poly1305 tag then covers both the encrypted length and the encrypted body, so
+ * a length an attacker has tampered with still fails authentication.
+ *
+ * Two other details are easy to get wrong and silent when wrong:
+ *
+ * The key halves are the other way round from how they read. The first 32 bytes
+ * of the 64 are K_2, which encrypts the body; the second 32 are K_1, for the
+ * length. Swapping them produces a cipher that is entirely self-consistent and
+ * cannot talk to anything.
+ *
+ * The Poly1305 key is block zero of the body key stream, and the body itself
+ * starts at block one. Encrypting the body from block zero would reuse the key
+ * stream that produced the authentication key.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class PacketCipher {
+
+    /** 512 bits: two 256-bit keys, per direction. */
+    public static final int KEY_LENGTH = 64;
+
+    public static final int TAG_LENGTH = Poly1305.TAG_LENGTH;
+
+    public static final int LENGTH_FIELD_LENGTH = 4;
+
+    /** The cipher is a stream cipher; 8 is what RFC 4253 uses when there is no block. */
+    public static final int BLOCK_SIZE = 8;
+
+    private static final int POLY1305_KEY_LENGTH = 32;
+
+    private final byte[] bodyKey;
+    private final byte[] lengthKey;
+
+    public PacketCipher(byte[] key) {
+        if (key.length != KEY_LENGTH) {
+            throw new IllegalArgumentException("key must be " + KEY_LENGTH + " bytes");
+        }
+        bodyKey = new byte[32];
+        lengthKey = new byte[32];
+        System.arraycopy(key, 0, bodyKey, 0, 32);
+        System.arraycopy(key, 32, lengthKey, 0, 32);
+    }
+
+    /**
+     * Encrypts a packet body and returns the bytes to put on the wire:
+     * the encrypted length, the encrypted body, then the tag.
+     */
+    public byte[] seal(long sequence, byte[] body) {
+        byte[] nonce = nonce(sequence);
+
+        byte[] out = new byte[LENGTH_FIELD_LENGTH + body.length + TAG_LENGTH];
+        out[0] = (byte) (body.length >>> 24);
+        out[1] = (byte) (body.length >>> 16);
+        out[2] = (byte) (body.length >>> 8);
+        out[3] = (byte) body.length;
+        new ChaCha20(lengthKey, nonce, 0).process(out, 0, LENGTH_FIELD_LENGTH);
+
+        System.arraycopy(body, 0, out, LENGTH_FIELD_LENGTH, body.length);
+        new ChaCha20(bodyKey, nonce, 1).process(out, LENGTH_FIELD_LENGTH, body.length);
+
+        byte[] tag = authenticate(nonce, out, LENGTH_FIELD_LENGTH + body.length);
+        System.arraycopy(tag, 0, out, LENGTH_FIELD_LENGTH + body.length, TAG_LENGTH);
+        return out;
+    }
+
+    /**
+     * Decrypts the length field alone, so the rest of the packet can be read.
+     *
+     * The value this returns is not yet trustworthy — nothing has been
+     * authenticated at this point. It is only safe to use for deciding how many
+     * bytes to read, and the caller must bound it before allocating anything.
+     */
+    public long peekLength(long sequence, byte[] encryptedLength) {
+        byte[] plain = new byte[LENGTH_FIELD_LENGTH];
+        System.arraycopy(encryptedLength, 0, plain, 0, LENGTH_FIELD_LENGTH);
+        new ChaCha20(lengthKey, nonce(sequence), 0).process(plain, 0, LENGTH_FIELD_LENGTH);
+        return ((long) (plain[0] & 0xff) << 24)
+             | ((long) (plain[1] & 0xff) << 16)
+             | ((long) (plain[2] & 0xff) << 8)
+             | (long) (plain[3] & 0xff);
+    }
+
+    /**
+     * Authenticates and then decrypts. In that order, and not the other way:
+     * plaintext derived from an unauthenticated packet must never reach the
+     * parser above, or the tag is decoration.
+     */
+    public byte[] open(long sequence, byte[] encryptedLength, byte[] encryptedBody, byte[] tag)
+            throws IOException {
+        byte[] nonce = nonce(sequence);
+
+        byte[] authenticated = new byte[LENGTH_FIELD_LENGTH + encryptedBody.length];
+        System.arraycopy(encryptedLength, 0, authenticated, 0, LENGTH_FIELD_LENGTH);
+        System.arraycopy(encryptedBody, 0, authenticated, LENGTH_FIELD_LENGTH, encryptedBody.length);
+
+        byte[] expected = authenticate(nonce, authenticated, authenticated.length);
+        if (!equalsConstantTime(expected, tag)) {
+            throw new SshException("packet authentication failed");
+        }
+
+        byte[] body = new byte[encryptedBody.length];
+        System.arraycopy(encryptedBody, 0, body, 0, encryptedBody.length);
+        new ChaCha20(bodyKey, nonce, 1).process(body, 0, body.length);
+        return body;
+    }
+
+    /** The Poly1305 key is block zero of the body key stream, freshly per packet. */
+    private byte[] authenticate(byte[] nonce, byte[] data, int length) {
+        byte[] key = new byte[POLY1305_KEY_LENGTH];
+        new ChaCha20(bodyKey, nonce, 0).process(key, 0, POLY1305_KEY_LENGTH);
+
+        Poly1305 mac = new Poly1305(key);
+        mac.update(data, 0, length);
+        return mac.finish();
+    }
+
+    /**
+     * The nonce is the sequence number, which is why a packet cannot be
+     * replayed or reordered: its number is part of what authenticates it.
+     * Four zero bytes then the sequence as a big-endian uint64 gives the same
+     * cipher state as OpenSSH's 64-bit-nonce ChaCha20 with a zero high counter.
+     */
+    private static byte[] nonce(long sequence) {
+        byte[] nonce = new byte[12];
+        for (int i = 0; i < 8; i++) {
+            nonce[4 + i] = (byte) (sequence >>> (56 - 8 * i));
+        }
+        return nonce;
+    }
+
+    /**
+     * Compared without an early exit. A comparison that stops at the first
+     * wrong byte tells an attacker how much of a forged tag was right, which is
+     * enough to build the rest of it a byte at a time.
+     */
+    private static boolean equalsConstantTime(byte[] a, byte[] b) {
+        if (a.length != b.length) {
+            return false;
+        }
+        int difference = 0;
+        for (int i = 0; i < a.length; i++) {
+            difference |= a[i] ^ b[i];
+        }
+        return difference == 0;
+    }
+}

--- a/ssh/src/berryssh/protocol/Transport.java
+++ b/ssh/src/berryssh/protocol/Transport.java
@@ -42,6 +42,8 @@ public final class Transport {
     /** Smallest legal packet, counting the length field itself. */
     private static final int MIN_PACKET = 16;
 
+    private static final int LENGTH_FIELD = 4;
+
     private final InputStream in;
     private final OutputStream out;
 
@@ -58,6 +60,14 @@ public final class Transport {
      * cipher's block size, or 8 for a stream cipher and for the null cipher.
      */
     private int blockSize = 8;
+
+    /**
+     * Null until NEWKEYS. The two directions are separate because NEWKEYS is
+     * itself directional: our packets become encrypted when we send ours, and
+     * the server's when it sends its own, and those are not the same moment.
+     */
+    private PacketCipher outgoing;
+    private PacketCipher incoming;
 
     private String clientVersion;
     private String serverVersion;
@@ -85,6 +95,16 @@ public final class Transport {
 
     public long receiveSequence() {
         return receiveSequence;
+    }
+
+    /** Takes effect from the next packet we send. Call it straight after sending NEWKEYS. */
+    public void encryptOutgoing(PacketCipher cipher) {
+        this.outgoing = cipher;
+    }
+
+    /** Takes effect from the next packet we read. Call it straight after reading NEWKEYS. */
+    public void decryptIncoming(PacketCipher cipher) {
+        this.incoming = cipher;
     }
 
     /**
@@ -130,52 +150,90 @@ public final class Transport {
      * with at least 4 bytes of padding and at least 16 bytes in total.
      */
     public void writePacket(byte[] payload) throws IOException {
-        int unpadded = 5 + payload.length;
-        int padLength = blockSize - (unpadded % blockSize);
-        if (padLength < 4) {
-            padLength += blockSize;
+        byte[] body = pad(payload);
+        if (outgoing == null) {
+            byte[] packet = new byte[4 + body.length];
+            packet[0] = (byte) (body.length >>> 24);
+            packet[1] = (byte) (body.length >>> 16);
+            packet[2] = (byte) (body.length >>> 8);
+            packet[3] = (byte) body.length;
+            System.arraycopy(body, 0, packet, 4, body.length);
+            out.write(packet, 0, packet.length);
+        } else {
+            byte[] sealed = outgoing.seal(sendSequence, body);
+            out.write(sealed, 0, sealed.length);
         }
-        while (unpadded + padLength < MIN_PACKET) {
-            padLength += blockSize;
-        }
-
-        int packetLength = 1 + payload.length + padLength;
-        byte[] packet = new byte[4 + packetLength];
-        packet[0] = (byte) (packetLength >>> 24);
-        packet[1] = (byte) (packetLength >>> 16);
-        packet[2] = (byte) (packetLength >>> 8);
-        packet[3] = (byte) packetLength;
-        packet[4] = (byte) padLength;
-        System.arraycopy(payload, 0, packet, 5, payload.length);
-        fillRandom(packet, 5 + payload.length, padLength);
-
-        out.write(packet, 0, packet.length);
         out.flush();
         sendSequence = (sendSequence + 1) & 0xffffffffL;
     }
 
+    /**
+     * Builds the padding-length byte, the payload and the padding.
+     *
+     * The alignment rule changes once the AEAD is in play. RFC 4253 counts the
+     * length field towards the block multiple; chacha20-poly1305 encrypts that
+     * field separately with its own key, so it is not part of the aligned run
+     * and is excluded here. Getting this wrong yields packets a server rejects
+     * as corrupt with no indication that padding is what it is objecting to.
+     */
+    private byte[] pad(byte[] payload) {
+        int aligned = 1 + payload.length + (outgoing == null ? LENGTH_FIELD : 0);
+        int padLength = blockSize - (aligned % blockSize);
+        if (padLength < 4) {
+            padLength += blockSize;
+        }
+        while (LENGTH_FIELD + 1 + payload.length + padLength < MIN_PACKET) {
+            padLength += blockSize;
+        }
+
+        byte[] body = new byte[1 + payload.length + padLength];
+        body[0] = (byte) padLength;
+        System.arraycopy(payload, 0, body, 1, payload.length);
+        fillRandom(body, 1 + payload.length, padLength);
+        return body;
+    }
+
     /** Reads one packet and returns its payload. */
     public byte[] readPacket() throws IOException {
-        byte[] header = new byte[4];
-        readFully(header, 0, 4);
-        long packetLength = ((long) (header[0] & 0xff) << 24)
-                          | ((long) (header[1] & 0xff) << 16)
-                          | ((long) (header[2] & 0xff) << 8)
-                          | (long) (header[3] & 0xff);
+        byte[] header = new byte[LENGTH_FIELD];
+        readFully(header, 0, LENGTH_FIELD);
 
-        // Every check here happens before the allocation on the next line.
-        if (packetLength < MIN_PACKET - 4) {
+        long packetLength;
+        if (incoming == null) {
+            packetLength = ((long) (header[0] & 0xff) << 24)
+                         | ((long) (header[1] & 0xff) << 16)
+                         | ((long) (header[2] & 0xff) << 8)
+                         | (long) (header[3] & 0xff);
+        } else {
+            // Decrypted, but not yet authenticated — the tag covers this field
+            // and has not been checked. It is only trusted enough to decide how
+            // many bytes to read, and it is bounded before anything is
+            // allocated on the strength of it.
+            packetLength = incoming.peekLength(receiveSequence, header);
+        }
+
+        int alignment = incoming == null ? LENGTH_FIELD : 0;
+        if (packetLength < MIN_PACKET - LENGTH_FIELD) {
             throw new SshException("packet of " + packetLength + " bytes is below the minimum");
         }
         if (packetLength > MAX_PACKET) {
             throw new SshException("packet of " + packetLength + " bytes is implausible");
         }
-        if ((packetLength + 4) % blockSize != 0) {
+        if ((packetLength + alignment) % blockSize != 0) {
             throw new SshException("packet is not a whole number of " + blockSize + "-byte blocks");
         }
 
-        byte[] body = new byte[(int) packetLength];
-        readFully(body, 0, body.length);
+        byte[] body;
+        if (incoming == null) {
+            body = new byte[(int) packetLength];
+            readFully(body, 0, body.length);
+        } else {
+            byte[] encrypted = new byte[(int) packetLength];
+            readFully(encrypted, 0, encrypted.length);
+            byte[] tag = new byte[PacketCipher.TAG_LENGTH];
+            readFully(tag, 0, tag.length);
+            body = incoming.open(receiveSequence, header, encrypted, tag);
+        }
 
         int padLength = body[0] & 0xff;
         if (padLength < 4 || padLength > body.length - 1) {


### PR DESCRIPTION
Implement the chacha20-poly1305@openssh.com packet layer

Not the RFC 8439 AEAD. The difference is the length field: a packet's length
has to be read before the packet can be, so it cannot sit inside the
authenticated ciphertext — but left in the clear it leaks the size of every
keystroke. OpenSSH's answer is a second key used for nothing else. The length
is encrypted alone under K_1, and the Poly1305 tag then covers both the
encrypted length and the encrypted body, so a length an attacker has altered
still fails authentication.

Four things here fail silently when wrong, which is why each has its own test:

The key halves read backwards. The first 32 bytes of the 64 are K_2, for the
body; the second 32 are K_1, for the length. Swap them and the result is a
cipher that is entirely self-consistent, round-trips its own packets perfectly,
and cannot talk to anything.

The Poly1305 key is block zero of the body key stream and the body starts at
block one. Starting the body at zero would encrypt it with the key stream that
produced its own authentication key.

The padding rule changes. RFC 4253 counts the length field towards the block
multiple; here it is encrypted separately and so is excluded. A server rejects
the result as corrupt without mentioning padding.

Authentication happens before decryption, and the tag comparison has no early
exit. A comparison that stops at the first wrong byte tells an attacker how much
of a forged tag was right, which is enough to build the rest a byte at a time.

Verified two ways. Offline, against a reference implementation written from
PROTOCOL.chacha20poly1305 rather than from this code. Against OpenSSH 9.2p1,
by completing the handshake through NEWKEYS and then making an encrypted
service request: the server authenticates and decrypts what we send, we
authenticate and decrypt its reply, and the sequence numbers stay in step. None
of that can pass with the keys swapped or the padding wrong.

Also adds Connection, which drives the handshake end to end. It returns the
host key rather than trusting it — the signature check proves the server holds
the private half of the key it presented, and says nothing about whether that
is the server the user meant to reach.

Closes #6.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

