### PR TITLE
Implement user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ spike2/run.sh
 
 **Crypto**: FIPS 180-4 for SHA-256 and SHA-512, RFC 8439 §2.4.2 / §2.5.2 /
 §2.8.2 for ChaCha20, Poly1305 and the AEAD construction, RFC 7748 §5.2 / §6.1
-for X25519, and RFC 8032 §7.1 plus negative cases for Ed25519, and the DRBG
-against vectors computed outside it. 38 in total.
+for X25519, RFC 8032 §7.1 for Ed25519 in both directions, and the DRBG
+against vectors computed outside it. 49 in total.
 
 **Transport**: RFC 4251 §5 for the wire types, RFC 4253 §6 for the packet
 framing and §7.1 for algorithm negotiation, RFC 8731 §3 for the exchange hash
 and RFC 4253 §7.2 for key derivation, plus base64, host key parsing, the
-version exchange, the chacha20-poly1305 packet layer and the paths that have
-to reject malformed input. 85 in total. They run under a Turkish default locale, which is the device's own and
+version exchange, the chacha20-poly1305 packet layer, UTF-8 and the paths
+that have to reject malformed input. 93 in total. They run under a Turkish default locale, which is the device's own and
 the setting most likely to break protocol code without raising an error
 anywhere.
 
@@ -149,7 +149,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] KEXINIT algorithm negotiation
 - [x] `curve25519-sha256` key exchange, host key check and key derivation
 - [x] `chacha20-poly1305@openssh.com` packet layer, and an encrypted handshake
-- [ ] User authentication
+- [x] User authentication: `none`, `password`, `publickey` with Ed25519
 - [ ] Channels, `pty-req`, shell
 - [ ] Terminal emulation and UI
 

--- a/spike2/src/CryptoTests.java
+++ b/spike2/src/CryptoTests.java
@@ -1,6 +1,7 @@
 import berryssh.crypto.ChaCha20;
 import berryssh.crypto.EntropyPool;
 import berryssh.crypto.Poly1305;
+import berryssh.crypto.ScalarModL;
 import berryssh.crypto.Ed25519;
 import berryssh.crypto.SHA256;
 import berryssh.crypto.SHA512;
@@ -26,6 +27,7 @@ public class CryptoTests {
         x25519Vectors();
         sha512Vectors();
         ed25519Vectors();
+        ed25519SigningVectors();
         entropyPoolVectors();
 
         System.out.println();
@@ -277,6 +279,81 @@ public class CryptoTests {
         for (int i = 0; i < 8; i++) {
             b[off + i] = (byte) (v >>> (8 * i));
         }
+    }
+
+    /**
+     * RFC 8032 section 7.1 again, from the other side. Signing has to reproduce
+     * the published signatures exactly — Ed25519 is deterministic, so there is
+     * one right answer per key and message and no tolerance anywhere in it.
+     *
+     * These also exercise the mod-L arithmetic that only signing needs. A fault
+     * in the reduction gives a signature that is wrong but well formed, which
+     * nothing but a known answer would catch.
+     */
+    private static void ed25519SigningVectors() {
+        String[][] vectors = {
+            // seed, public key, message, signature
+            { "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+              "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+              "",
+              "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e06522490155"
+                + "5fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b" },
+            { "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb",
+              "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+              "72",
+              "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da"
+                + "085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00" },
+            { "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7",
+              "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+              "af82",
+              "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac"
+                + "18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a" }
+        };
+
+        for (int i = 0; i < vectors.length; i++) {
+            byte[] seed = hex(vectors[i][0]);
+            byte[] message = hex(vectors[i][2]);
+            check("Ed25519 public key from seed, RFC 8032 TEST " + (i + 1),
+                Ed25519.publicKey(seed), vectors[i][1]);
+            check("Ed25519 signature, RFC 8032 TEST " + (i + 1),
+                Ed25519.sign(seed, message), vectors[i][3]);
+        }
+
+        // The two halves have to agree with each other as well as with the RFC,
+        // across a message long enough to span several hash blocks.
+        byte[] seed = hex("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7");
+        byte[] longMessage = new byte[1000];
+        for (int i = 0; i < longMessage.length; i++) {
+            longMessage[i] = (byte) (i * 7);
+        }
+        byte[] signature = Ed25519.sign(seed, longMessage);
+        checkTrue("a signature we produced verifies under the key we derived",
+            Ed25519.verify(Ed25519.publicKey(seed), longMessage, signature));
+
+        byte[] tampered = new byte[longMessage.length];
+        System.arraycopy(longMessage, 0, tampered, 0, longMessage.length);
+        tampered[500] ^= 0x01;
+        checkTrue("that signature does not verify over a changed message",
+            !Ed25519.verify(Ed25519.publicKey(seed), tampered, signature));
+
+        // Mod-L arithmetic on its own. L reduces to zero, and L-1 is unchanged:
+        // the two cases either side of the boundary the reduction turns on.
+        byte[] order = hex("edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010");
+        check("L reduces to zero", ScalarModL.reduce(order), repeat("00", 32));
+        byte[] orderMinusOne = hex("ecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010");
+        check("L-1 is left alone", ScalarModL.reduce(orderMinusOne),
+            "ecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010");
+        check("L+1 reduces to one", ScalarModL.reduce(
+            hex("eed3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010")),
+            "01" + repeat("00", 31));
+    }
+
+    private static String repeat(String s, int times) {
+        StringBuffer sb = new StringBuffer(s.length() * times);
+        for (int i = 0; i < times; i++) {
+            sb.append(s);
+        }
+        return sb.toString();
     }
 
     /**

--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -6,6 +6,7 @@ import berryssh.protocol.KeyExchange;
 import berryssh.protocol.Message;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.Transport;
+import berryssh.protocol.UserAuth;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -27,6 +28,8 @@ public class ServerTests {
 
     private static String host = "127.0.0.1";
     private static int port = 2222;
+    private static String user = "bb";
+    private static String password = "bbssh";
 
     private static int passed;
     private static int failed;
@@ -38,11 +41,16 @@ public class ServerTests {
         if (args.length >= 2) {
             port = Integer.parseInt(args[1]);
         }
+        if (args.length >= 4) {
+            user = args[2];
+            password = args[3];
+        }
 
         System.out.println("  ..    against " + host + ":" + port);
         negotiatesWithRealServer();
         exchangesKeysWithRealServer();
         encryptsWithRealServer();
+        authenticatesWithRealServer();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -188,6 +196,83 @@ public class ServerTests {
         } finally {
             socket.close();
         }
+    }
+
+    /**
+     * RFC 4252 against the real server: what it will accept, a wrong password,
+     * a right one, and a publickey request it can parse.
+     */
+    private static void authenticatesWithRealServer() throws Exception {
+        Socket socket = new Socket(host, port);
+        try {
+            socket.setSoTimeout(15000);
+            EntropyPool random = new EntropyPool();
+            random.seed();
+            Connection connection = new Connection(
+                socket.getInputStream(), socket.getOutputStream(), random);
+            connection.handshake();
+
+            UserAuth auth = new UserAuth(connection, user);
+            auth.begin();
+
+            // "none" is not a way in; it is how you ask what the server wants,
+            // and its failure carries the answer.
+            UserAuth.Result none = auth.queryMethods();
+            checkTrue("the none method is refused and names what can continue",
+                !none.succeeded() && none.methodsThatCanContinue().length > 0);
+            System.out.println("        server accepts " + join(none.methodsThatCanContinue()));
+
+            boolean offersPassword = false;
+            boolean offersPublicKey = false;
+            for (int i = 0; i < none.methodsThatCanContinue().length; i++) {
+                String method = none.methodsThatCanContinue()[i];
+                if ("password".equals(method)) {
+                    offersPassword = true;
+                }
+                if ("publickey".equals(method)) {
+                    offersPublicKey = true;
+                }
+            }
+            checkTrue("the server offers password and publickey",
+                offersPassword && offersPublicKey);
+
+            // A publickey request the server can parse. This key is not in any
+            // authorized_keys, so the attempt must fail — what it demonstrates
+            // is that the request and key blob are well formed enough for the
+            // server to read the key out and name it in its log.
+            UserAuth.Result byKey = auth.publicKey(
+                hex("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7"));
+            checkTrue("an unauthorised publickey request is parsed and refused",
+                !byKey.succeeded() && byKey.methodsThatCanContinue().length > 0);
+
+            UserAuth.Result wrong = auth.password("not the password");
+            checkTrue("a wrong password is refused",
+                !wrong.succeeded() && !wrong.partialSuccess());
+
+            UserAuth.Result right = auth.password(password);
+            checkTrue("the right password is accepted", right.succeeded());
+        } finally {
+            socket.close();
+        }
+    }
+
+    private static String join(String[] names) {
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < names.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(names[i]);
+        }
+        return sb.toString();
+    }
+
+    private static byte[] hex(String s) {
+        byte[] b = new byte[s.length() / 2];
+        for (int i = 0; i < b.length; i++) {
+            b[i] = (byte) Integer.parseInt(s.substring(2 * i, 2 * i + 2), 16);
+        }
+        return b;
     }
 
     private static boolean sameBytes(byte[] a, byte[] b) {

--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -7,6 +7,7 @@ import berryssh.protocol.PacketCipher;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.SshException;
 import berryssh.protocol.Transport;
+import berryssh.protocol.Utf8;
 import berryssh.protocol.WireReader;
 import berryssh.protocol.WireWriter;
 
@@ -55,6 +56,7 @@ public class TransportTests {
         exchangeHashVectors();
         packetCipherVectors();
         encryptedFraming();
+        utf8Vectors();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -617,9 +619,12 @@ public class TransportTests {
                 byte[] wire = sink.toByteArray();
 
                 // The encrypted run between the length field and the tag is
-                // what has to be a whole number of blocks.
+                // what has to be a whole number of blocks. RFC 4253's 16-byte
+                // floor does not apply here — it exists for block ciphers, and
+                // OpenSSH sends an 8-byte body for a one-byte message, so
+                // requiring more would reject a real server's packets.
                 int encrypted = wire.length - 4 - PacketCipher.TAG_LENGTH;
-                if (encrypted % 8 != 0 || wire.length < 16 + PacketCipher.TAG_LENGTH) {
+                if (encrypted % 8 != 0 || encrypted < 8) {
                     allAligned = false;
                 }
 
@@ -648,6 +653,50 @@ public class TransportTests {
             new Transport(new ByteArrayInputStream(sink.toByteArray()),
                           new ByteArrayOutputStream()).readPacket();
         });
+    }
+
+    /**
+     * UTF-8, which RFC 4252 requires for usernames and passwords while the
+     * device's default encoding is ISO8859_1.
+     *
+     * The Turkish characters are the case that matters rather than an
+     * illustration: under ISO8859_1 they encode to one byte each and the server
+     * would compare the wrong bytes, reporting only that the login failed.
+     */
+    private static void utf8Vectors() {
+        check("UTF-8 ASCII is unchanged", Utf8.encode("bb"), "6262");
+
+        // U+00E7 U+011F U+0131 U+00F6 U+015F U+00FC — the six Turkish letters.
+        check("UTF-8 encodes the Turkish letters",
+            Utf8.encode("çğıöşü"),
+            "c3a7c49fc4b1c3b6c59fc3bc");
+        checkTrue("a Turkish password is 6 characters and 12 bytes",
+            "çğıöşü".length() == 6
+                && Utf8.encode("çğıöşü").length == 12);
+
+        check("UTF-8 encodes a three-byte code point", Utf8.encode("€"), "e282ac");
+        // U+1F600, which Java holds as a surrogate pair.
+        check("UTF-8 encodes a surrogate pair as one four-byte sequence",
+            Utf8.encode("😀"), "f09f9880");
+
+        String[] roundTrips = {
+            "", "bb", "çğıöşü", "€",
+            "😀", "karışık ASCII ve Türkçe"
+        };
+        boolean allRoundTripped = true;
+        for (int i = 0; i < roundTrips.length; i++) {
+            if (!roundTrips[i].equals(Utf8.decode(Utf8.encode(roundTrips[i])))) {
+                allRoundTripped = false;
+            }
+        }
+        checkTrue("UTF-8 round trips, including outside the basic plane", allRoundTripped);
+
+        // One bad byte should cost one character, not the session: this decodes
+        // terminal output, where throwing would be the wrong response.
+        checkTrue("a malformed byte becomes one replacement character",
+            "a�b".equals(Utf8.decode(hex("61ff62"))));
+        checkTrue("a truncated sequence at the end does not run off the array",
+            Utf8.decode(hex("61c3")).length() == 2);
     }
 
     private static byte[] slice(byte[] b, int offset, int length) {

--- a/ssh/src/berryssh/crypto/Ed25519.java
+++ b/ssh/src/berryssh/crypto/Ed25519.java
@@ -323,6 +323,80 @@ public final class Ed25519 {
         return false;   // equal to L is not below it
     }
 
+    /** The 32-byte seed an OpenSSH ed25519 private key stores. */
+    public static final int SEED_LENGTH = 32;
+
+    /**
+     * Expands a 32-byte seed into the scalar and the prefix RFC 8032 section
+     * 5.1.5 derives from it.
+     *
+     * The pruning is not optional and not cosmetic: clearing the low three bits
+     * puts the scalar in the prime-order subgroup, and forcing bit 254 fixes
+     * its length so that a variable-time ladder cannot leak it.
+     */
+    private static byte[] expandSeed(byte[] seed) {
+        byte[] h = SHA512.hash(seed);
+        h[0] &= (byte) 248;
+        h[31] &= (byte) 127;
+        h[31] |= (byte) 64;
+        return h;
+    }
+
+    /** Derives the public key from a 32-byte seed. */
+    public static byte[] publicKey(byte[] seed) {
+        if (seed == null || seed.length != SEED_LENGTH) {
+            throw new IllegalArgumentException("seed must be " + SEED_LENGTH + " bytes");
+        }
+        byte[] h = expandSeed(seed);
+        byte[] a = new byte[32];
+        System.arraycopy(h, 0, a, 0, 32);
+        return compress(scalarMult(BASE, a, 255));
+    }
+
+    /**
+     * Signs a message with a 32-byte seed, per RFC 8032 section 5.1.6.
+     *
+     * Ed25519 signatures are deterministic: the per-signature nonce comes from
+     * hashing the message under the second half of the expanded seed rather
+     * than from a random source. That is a property worth having on this
+     * hardware in particular — a handset has very little entropy, and a
+     * signature scheme that leaks its key when the nonce repeats would be the
+     * worst possible consumer of it.
+     *
+     * @param seed 32 bytes, the private key as OpenSSH stores it
+     * @return 64 bytes: R followed by S
+     */
+    public static byte[] sign(byte[] seed, byte[] message) {
+        if (seed == null || seed.length != SEED_LENGTH) {
+            throw new IllegalArgumentException("seed must be " + SEED_LENGTH + " bytes");
+        }
+        byte[] h = expandSeed(seed);
+        byte[] a = new byte[32];
+        System.arraycopy(h, 0, a, 0, 32);
+
+        byte[] publicKey = compress(scalarMult(BASE, a, 255));
+
+        SHA512 nonce = new SHA512();
+        nonce.update(h, 32, 32);
+        nonce.update(message, 0, message.length);
+        byte[] r = ScalarModL.reduce(nonce.digest());
+
+        byte[] rPoint = compress(scalarMult(BASE, r, 253));
+
+        SHA512 challenge = new SHA512();
+        challenge.update(rPoint, 0, 32);
+        challenge.update(publicKey, 0, 32);
+        challenge.update(message, 0, message.length);
+        byte[] k = ScalarModL.reduce(challenge.digest());
+
+        byte[] s = ScalarModL.mulAdd(k, a, r);
+
+        byte[] signature = new byte[SIGNATURE_LENGTH];
+        System.arraycopy(rPoint, 0, signature, 0, 32);
+        System.arraycopy(s, 0, signature, 32, 32);
+        return signature;
+    }
+
     /**
      * Verifies a signature over a message.
      *

--- a/ssh/src/berryssh/crypto/ScalarModL.java
+++ b/ssh/src/berryssh/crypto/ScalarModL.java
@@ -1,0 +1,165 @@
+package berryssh.crypto;
+
+/**
+ * Arithmetic modulo L, the order of the Ed25519 base point.
+ *
+ * L = 2^252 + 27742317777372353535851937790883648493. Signing needs two
+ * operations there: reducing a 64-byte hash into a scalar, and computing
+ * (k*a + r) mod L. Verification needed neither, which is why this arrives with
+ * signing rather than with the curve.
+ *
+ * The reduction is bitwise long division — shift a bit in, conditionally
+ * subtract L — rather than the packed 21-bit limb arithmetic the reference
+ * implementations use. That is perhaps fifty times slower and it is the right
+ * trade here: it runs once per signature, which is once per connection, and
+ * unlike the limb version it can be read and checked by eye. There is no
+ * BigInteger in CLDC to fall back on if the clever version were wrong.
+ *
+ * Everything is little-endian, as Ed25519 is throughout.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class ScalarModL {
+
+    /** L in 32-bit little-endian limbs. */
+    private static final int[] L = {
+        0x5cf5d3ed, 0x5812631a, 0xa2f79cd6, 0x14def9de,
+        0x00000000, 0x00000000, 0x00000000, 0x10000000
+    };
+
+    private static final int LIMBS = 8;
+
+    public static final int LENGTH = 32;
+
+    private ScalarModL() {
+    }
+
+    /**
+     * Reduces a little-endian value of any length modulo L.
+     *
+     * Bits go in from the top; the running remainder stays below L, so after
+     * doubling it is below 2L and a single conditional subtraction restores the
+     * invariant. That bound is why eight limbs are always enough.
+     */
+    public static byte[] reduce(byte[] value, int length) {
+        int[] r = new int[LIMBS];
+        for (int bit = length * 8 - 1; bit >= 0; bit--) {
+            int in = (value[bit >> 3] >>> (bit & 7)) & 1;
+            shiftInBit(r, in);
+            if (compare(r, L) >= 0) {
+                subtract(r, L);
+            }
+        }
+        return toBytes(r);
+    }
+
+    public static byte[] reduce(byte[] value) {
+        return reduce(value, value.length);
+    }
+
+    /**
+     * (a * b + c) mod L, the value of S in an Ed25519 signature.
+     *
+     * The product is computed at full width and reduced once at the end rather
+     * than reduced as it goes, which keeps the two steps independent of one
+     * another and separately checkable.
+     */
+    public static byte[] mulAdd(byte[] a, byte[] b, byte[] c) {
+        byte[] product = multiply(a, b);
+        byte[] sum = add(product, c);
+        return reduce(sum, sum.length);
+    }
+
+    /** Schoolbook multiplication of little-endian byte arrays. */
+    static byte[] multiply(byte[] a, byte[] b) {
+        int[] acc = new int[a.length + b.length];
+        for (int i = 0; i < a.length; i++) {
+            int ai = a[i] & 0xff;
+            if (ai == 0) {
+                continue;
+            }
+            int carry = 0;
+            for (int j = 0; j < b.length; j++) {
+                // At most 255*255 + 255 + 255, so an int is never close to full.
+                int t = acc[i + j] + ai * (b[j] & 0xff) + carry;
+                acc[i + j] = t & 0xff;
+                carry = t >>> 8;
+            }
+            int at = i + b.length;
+            while (carry != 0) {
+                int t = acc[at] + carry;
+                acc[at] = t & 0xff;
+                carry = t >>> 8;
+                at++;
+            }
+        }
+        byte[] out = new byte[acc.length];
+        for (int i = 0; i < acc.length; i++) {
+            out[i] = (byte) acc[i];
+        }
+        return out;
+    }
+
+    /** Little-endian addition, widened by one byte so nothing is lost. */
+    static byte[] add(byte[] a, byte[] b) {
+        int length = (a.length > b.length ? a.length : b.length) + 1;
+        byte[] out = new byte[length];
+        int carry = 0;
+        for (int i = 0; i < length; i++) {
+            int t = carry;
+            if (i < a.length) {
+                t += a[i] & 0xff;
+            }
+            if (i < b.length) {
+                t += b[i] & 0xff;
+            }
+            out[i] = (byte) t;
+            carry = t >>> 8;
+        }
+        return out;
+    }
+
+    private static void shiftInBit(int[] r, int in) {
+        int carry = in;
+        for (int i = 0; i < LIMBS; i++) {
+            int next = r[i] >>> 31;
+            r[i] = (r[i] << 1) | carry;
+            carry = next;
+        }
+    }
+
+    /** Unsigned comparison, most significant limb first. */
+    private static int compare(int[] a, int[] b) {
+        for (int i = LIMBS - 1; i >= 0; i--) {
+            long x = a[i] & 0xffffffffL;
+            long y = b[i] & 0xffffffffL;
+            if (x < y) {
+                return -1;
+            }
+            if (x > y) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    private static void subtract(int[] a, int[] b) {
+        long borrow = 0;
+        for (int i = 0; i < LIMBS; i++) {
+            long t = (a[i] & 0xffffffffL) - (b[i] & 0xffffffffL) - borrow;
+            a[i] = (int) t;
+            borrow = (t >> 32) & 1;
+        }
+    }
+
+    private static byte[] toBytes(int[] r) {
+        byte[] out = new byte[LENGTH];
+        for (int i = 0; i < LIMBS; i++) {
+            out[4 * i] = (byte) r[i];
+            out[4 * i + 1] = (byte) (r[i] >>> 8);
+            out[4 * i + 2] = (byte) (r[i] >>> 16);
+            out[4 * i + 3] = (byte) (r[i] >>> 24);
+        }
+        return out;
+    }
+}

--- a/ssh/src/berryssh/protocol/Transport.java
+++ b/ssh/src/berryssh/protocol/Transport.java
@@ -182,7 +182,12 @@ public final class Transport {
         if (padLength < 4) {
             padLength += blockSize;
         }
-        while (LENGTH_FIELD + 1 + payload.length + padLength < MIN_PACKET) {
+        // RFC 4253's 16-byte floor exists so a block cipher always gets a whole
+        // block. It does not apply to the AEAD, and OpenSSH does not apply it
+        // there either — padding to 16 anyway would put eight wasted bytes on
+        // every keystroke, on a link where that is the expensive direction.
+        while (outgoing == null
+                && LENGTH_FIELD + 1 + payload.length + padLength < MIN_PACKET) {
             padLength += blockSize;
         }
 
@@ -212,8 +217,13 @@ public final class Transport {
             packetLength = incoming.peekLength(receiveSequence, header);
         }
 
+        // The floor differs with the cipher for the same reason the padding
+        // does: under the AEAD the smallest legal body is one block holding the
+        // padding-length byte, a message type and four bytes of padding, and a
+        // real server sends exactly that for a one-byte message.
         int alignment = incoming == null ? LENGTH_FIELD : 0;
-        if (packetLength < MIN_PACKET - LENGTH_FIELD) {
+        int minimum = incoming == null ? MIN_PACKET - LENGTH_FIELD : blockSize;
+        if (packetLength < minimum) {
             throw new SshException("packet of " + packetLength + " bytes is below the minimum");
         }
         if (packetLength > MAX_PACKET) {

--- a/ssh/src/berryssh/protocol/UserAuth.java
+++ b/ssh/src/berryssh/protocol/UserAuth.java
@@ -1,0 +1,187 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+import berryssh.crypto.Ed25519;
+
+/**
+ * User authentication, RFC 4252.
+ *
+ * The shape of the exchange is worth stating because it is not obvious: a
+ * failure carries the list of methods that could still work, so the `none`
+ * method is not a way of logging in but a way of asking what the server will
+ * accept. It is expected to fail, and its failure is the useful part.
+ *
+ * Usernames and passwords go on the wire as UTF-8 regardless of what the
+ * device's default encoding is — see {@link Utf8} for why that is not a
+ * theoretical point here.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class UserAuth {
+
+    /** The service authentication is a gateway to. */
+    public static final String CONNECTION_SERVICE = "ssh-connection";
+
+    private static final String AUTH_SERVICE = "ssh-userauth";
+
+    private final Connection connection;
+    private final String user;
+    private String banner;
+
+    public UserAuth(Connection connection, String user) {
+        this.connection = connection;
+        this.user = user;
+    }
+
+    /**
+     * Anything the server asked to be shown to the user.
+     *
+     * A banner is often the one place a server states its terms of use, so it
+     * is collected rather than dropped, and it can arrive at any point during
+     * authentication including before the first request.
+     */
+    public String banner() {
+        return banner;
+    }
+
+    /** The outcome of one attempt. */
+    public static final class Result {
+
+        private final boolean succeeded;
+        private final boolean partial;
+        private final String[] continueWith;
+
+        Result(boolean succeeded, boolean partial, String[] continueWith) {
+            this.succeeded = succeeded;
+            this.partial = partial;
+            this.continueWith = continueWith;
+        }
+
+        public boolean succeeded() {
+            return succeeded;
+        }
+
+        /**
+         * True when the method was accepted but the server wants another one as
+         * well. The attempt worked; the session is simply not open yet, and
+         * treating this as a failure would send the user round to retype a
+         * password that was already correct.
+         */
+        public boolean partialSuccess() {
+            return partial;
+        }
+
+        /** The methods the server says could still succeed. */
+        public String[] methodsThatCanContinue() {
+            return continueWith;
+        }
+    }
+
+    /** Starts the authentication service. Must be called before any attempt. */
+    public void begin() throws IOException {
+        connection.requestService(AUTH_SERVICE);
+    }
+
+    /**
+     * Asks the server what it will accept, using the `none` method.
+     *
+     * A server with no authentication configured at all may accept this, which
+     * is why the result is returned rather than assumed to be a failure.
+     */
+    public Result queryMethods() throws IOException {
+        WireWriter w = request("none");
+        connection.transport().writePacket(w.toByteArray());
+        return readOutcome();
+    }
+
+    public Result password(String password) throws IOException {
+        WireWriter w = request("password");
+        w.writeBoolean(false);
+        w.writeString(Utf8.encode(password));
+        connection.transport().writePacket(w.toByteArray());
+        return readOutcome();
+    }
+
+    /**
+     * Authenticates with an Ed25519 key, given the 32-byte seed OpenSSH stores
+     * as the private key.
+     *
+     * The signature covers the session identifier as well as the request. That
+     * binding is what stops a server from taking a signature made against it
+     * and replaying it to a third party as the user: the session identifier
+     * differs for every connection, so the signature only means anything on
+     * the one it was made for.
+     */
+    public Result publicKey(byte[] seed) throws IOException {
+        byte[] publicKey = Ed25519.publicKey(seed);
+
+        WireWriter blob = new WireWriter(64);
+        blob.writeAsciiString(HostKey.ALGORITHM);
+        blob.writeString(publicKey);
+        byte[] keyBlob = blob.toByteArray();
+
+        WireWriter signed = new WireWriter(256);
+        signed.writeString(connection.sessionId());
+        appendRequest(signed, "publickey");
+        signed.writeBoolean(true);
+        signed.writeAsciiString(HostKey.ALGORITHM);
+        signed.writeString(keyBlob);
+
+        byte[] signature = Ed25519.sign(seed, signed.toByteArray());
+        WireWriter signatureBlob = new WireWriter(96);
+        signatureBlob.writeAsciiString(HostKey.ALGORITHM);
+        signatureBlob.writeString(signature);
+
+        WireWriter w = request("publickey");
+        w.writeBoolean(true);
+        w.writeAsciiString(HostKey.ALGORITHM);
+        w.writeString(keyBlob);
+        w.writeString(signatureBlob.toByteArray());
+        connection.transport().writePacket(w.toByteArray());
+        return readOutcome();
+    }
+
+    private WireWriter request(String method) {
+        WireWriter w = new WireWriter(256);
+        appendRequest(w, method);
+        return w;
+    }
+
+    private void appendRequest(WireWriter w, String method) {
+        w.writeByte(Message.USERAUTH_REQUEST);
+        w.writeString(Utf8.encode(user));
+        w.writeAsciiString(CONNECTION_SERVICE);
+        w.writeAsciiString(method);
+    }
+
+    private Result readOutcome() throws IOException {
+        for (;;) {
+            byte[] payload = connection.transport().readMessage();
+            int type = payload[0] & 0xff;
+
+            if (type == Message.USERAUTH_BANNER) {
+                WireReader r = new WireReader(payload);
+                r.readByte();
+                banner = Utf8.decode(r.readString());
+                continue;
+            }
+            if (type == Message.USERAUTH_SUCCESS) {
+                return new Result(true, false, new String[0]);
+            }
+            if (type == Message.USERAUTH_FAILURE) {
+                WireReader r = new WireReader(payload);
+                r.readByte();
+                String[] continueWith = r.readNameList();
+                boolean partial = r.readBoolean();
+                return new Result(false, partial, continueWith);
+            }
+            // 60 is method-specific. In the publickey method it is PK_OK, an
+            // answer to a query we never send: we always sign up front, because
+            // asking first costs an extra round trip on a link where round
+            // trips are the expensive part.
+            throw new SshException("unexpected " + Message.name(type)
+                + " during authentication");
+        }
+    }
+}

--- a/ssh/src/berryssh/protocol/Utf8.java
+++ b/ssh/src/berryssh/protocol/Utf8.java
@@ -1,0 +1,142 @@
+package berryssh.protocol;
+
+/**
+ * UTF-8, done by hand.
+ *
+ * RFC 4252 says usernames and passwords go on the wire as UTF-8, and the
+ * device's default encoding is ISO8859_1 — so `String.getBytes()` would send
+ * something else entirely and the platform offers no way to ask for UTF-8 that
+ * is dependable across CLDC implementations.
+ *
+ * This is not a theoretical concern for the intended user. A Turkish password
+ * containing ç, ğ, ı, ö, ş or ü encodes to one byte per character under
+ * ISO8859_1 and two under UTF-8; the server would compare the wrong bytes and
+ * report nothing more than a failed login.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Utf8 {
+
+    private Utf8() {
+    }
+
+    public static byte[] encode(String s) {
+        int length = 0;
+        for (int i = 0; i < s.length(); i++) {
+            int c = s.charAt(i);
+            if (c < 0x80) {
+                length += 1;
+            } else if (c < 0x800) {
+                length += 2;
+            } else if (isHighSurrogate(c) && i + 1 < s.length()
+                    && isLowSurrogate(s.charAt(i + 1))) {
+                length += 4;
+                i++;
+            } else {
+                length += 3;
+            }
+        }
+
+        byte[] out = new byte[length];
+        int at = 0;
+        for (int i = 0; i < s.length(); i++) {
+            int c = s.charAt(i);
+            if (c < 0x80) {
+                out[at++] = (byte) c;
+            } else if (c < 0x800) {
+                out[at++] = (byte) (0xc0 | (c >> 6));
+                out[at++] = (byte) (0x80 | (c & 0x3f));
+            } else if (isHighSurrogate(c) && i + 1 < s.length()
+                    && isLowSurrogate(s.charAt(i + 1))) {
+                // A code point above the basic plane is two chars in Java and
+                // one four-byte sequence here.
+                int codePoint = 0x10000 + ((c - 0xd800) << 10) + (s.charAt(i + 1) - 0xdc00);
+                i++;
+                out[at++] = (byte) (0xf0 | (codePoint >> 18));
+                out[at++] = (byte) (0x80 | ((codePoint >> 12) & 0x3f));
+                out[at++] = (byte) (0x80 | ((codePoint >> 6) & 0x3f));
+                out[at++] = (byte) (0x80 | (codePoint & 0x3f));
+            } else {
+                out[at++] = (byte) (0xe0 | (c >> 12));
+                out[at++] = (byte) (0x80 | ((c >> 6) & 0x3f));
+                out[at++] = (byte) (0x80 | (c & 0x3f));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Decodes, substituting U+FFFD for anything malformed.
+     *
+     * Replacing rather than throwing is deliberate: this decodes server banners
+     * and terminal output, where one bad byte should cost one character and not
+     * the session.
+     */
+    public static String decode(byte[] b, int offset, int length) {
+        char[] out = new char[length * 2];
+        int at = 0;
+        int i = offset;
+        int end = offset + length;
+        while (i < end) {
+            int c = b[i++] & 0xff;
+            int codePoint;
+            int extra;
+            if (c < 0x80) {
+                out[at++] = (char) c;
+                continue;
+            } else if ((c & 0xe0) == 0xc0) {
+                codePoint = c & 0x1f;
+                extra = 1;
+            } else if ((c & 0xf0) == 0xe0) {
+                codePoint = c & 0x0f;
+                extra = 2;
+            } else if ((c & 0xf8) == 0xf0) {
+                codePoint = c & 0x07;
+                extra = 3;
+            } else {
+                out[at++] = '�';
+                continue;
+            }
+
+            if (i + extra > end) {
+                out[at++] = '�';
+                break;
+            }
+            boolean valid = true;
+            for (int j = 0; j < extra; j++) {
+                int next = b[i + j] & 0xff;
+                if ((next & 0xc0) != 0x80) {
+                    valid = false;
+                    break;
+                }
+                codePoint = (codePoint << 6) | (next & 0x3f);
+            }
+            if (!valid) {
+                out[at++] = '�';
+                continue;
+            }
+            i += extra;
+
+            if (codePoint > 0xffff) {
+                codePoint -= 0x10000;
+                out[at++] = (char) (0xd800 + (codePoint >> 10));
+                out[at++] = (char) (0xdc00 + (codePoint & 0x3ff));
+            } else {
+                out[at++] = (char) codePoint;
+            }
+        }
+        return new String(out, 0, at);
+    }
+
+    public static String decode(byte[] b) {
+        return decode(b, 0, b.length);
+    }
+
+    private static boolean isHighSurrogate(int c) {
+        return c >= 0xd800 && c <= 0xdbff;
+    }
+
+    private static boolean isLowSurrogate(int c) {
+        return c >= 0xdc00 && c <= 0xdfff;
+    }
+}


### PR DESCRIPTION
Implement user authentication

RFC 4252: none, password, and publickey with Ed25519. Password authentication
against OpenSSH 9.2p1 now works end to end.

The `none` method is not a way in. Its failure carries the list of methods that
could still succeed, so it is how you ask the server what it wants, and it is
expected to fail. Only a server with no authentication at all accepts it, which
is why the result is returned rather than assumed.

Signing is new. Verification (#2) never needed arithmetic modulo L, and signing
needs it twice: reducing a 64-byte hash to a scalar, and computing (k*a + r).
That arrives as ScalarModL, which does bitwise long division rather than the
packed 21-bit limbs the reference implementations use. It is perhaps fifty
times slower and that is the right trade — it runs once per connection, and
unlike the limb version it can be checked by eye. There is no BigInteger in
CLDC to fall back on if the clever version were subtly wrong. RFC 8032's
published signatures are reproduced exactly, which is the only acceptable
result: Ed25519 is deterministic, so there is one right answer and no tolerance
anywhere in it.

The publickey signature covers the session identifier as well as the request.
That binding is what stops a server from taking a signature made against it and
replaying it to a third party as the user.

Usernames and passwords go on the wire as UTF-8, encoded by hand. The device's
default encoding is ISO8859_1, and for this user in particular that is not a
theoretical point: a password containing ç, ğ, ı, ö, ş or ü is one byte per
character under ISO8859_1 and two under UTF-8, so the server would compare the
wrong bytes and report nothing more than a failed login.

The real server also found a bug the offline vectors could not. RFC 4253's
16-byte minimum packet size exists so a block cipher always gets a whole block,
and it does not apply under the AEAD — OpenSSH sends an 8-byte body for a
one-byte message such as USERAUTH_SUCCESS. We were rejecting those on read and
over-padding by eight bytes on write, which on this link is eight wasted bytes
per keystroke in the expensive direction.

Publickey is verified as far as it can be here: the signing matches RFC 8032,
and the server parses our request and answers in protocol rather than
disconnecting. That the server would *accept* the signature is unproven,
because it needs a key in an authorized_keys file and installing one is a
change to a machine that should be the owner's call.

Closes #7.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

