### PR TITLE
Implement the session channel, pty-req and shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] `curve25519-sha256` key exchange, host key check and key derivation
 - [x] `chacha20-poly1305@openssh.com` packet layer, and an encrypted handshake
 - [x] User authentication: `none`, `password`, `publickey` with Ed25519
-- [ ] Channels, `pty-req`, shell
+- [x] Channels, `pty-req`, shell — a working session against OpenSSH 9.2p1
 - [ ] Terminal emulation and UI
 
 ## Prior art

--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -1,4 +1,5 @@
 import berryssh.crypto.EntropyPool;
+import berryssh.protocol.Channel;
 import berryssh.protocol.Connection;
 import berryssh.protocol.HostKey;
 import berryssh.protocol.KexInit;
@@ -7,6 +8,7 @@ import berryssh.protocol.Message;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.Transport;
 import berryssh.protocol.UserAuth;
+import berryssh.protocol.Utf8;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -51,6 +53,7 @@ public class ServerTests {
         exchangesKeysWithRealServer();
         encryptsWithRealServer();
         authenticatesWithRealServer();
+        runsAShellOnRealServer();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -251,6 +254,68 @@ public class ServerTests {
 
             UserAuth.Result right = auth.password(password);
             checkTrue("the right password is accepted", right.succeeded());
+        } finally {
+            socket.close();
+        }
+    }
+
+    /**
+     * The whole thing: handshake, authenticate, take a pty, run a shell, and
+     * read back what it printed.
+     *
+     * This is the test the project is for. Everything below it has to be right
+     * simultaneously — a wrong exchange hash, a swapped cipher key, a padding
+     * rule off by eight, a mis-encoded password or a forgotten window update
+     * each stop it, and none of them can be compensated for by another.
+     */
+    private static void runsAShellOnRealServer() throws Exception {
+        Socket socket = new Socket(host, port);
+        try {
+            socket.setSoTimeout(20000);
+            EntropyPool random = new EntropyPool();
+            random.seed();
+            Connection connection = new Connection(
+                socket.getInputStream(), socket.getOutputStream(), random);
+            connection.handshake();
+
+            UserAuth auth = new UserAuth(connection, user);
+            auth.begin();
+            auth.queryMethods();
+            checkTrue("authenticated for the shell test", auth.password(password).succeeded());
+
+            Channel channel = Channel.openSession(connection);
+            checkTrue("a session channel opens", channel != null);
+
+            // 60x25 is what an 8x14 bitmap cell gives on the device's 480x360
+            // canvas, so the server is told the size the terminal will be.
+            channel.requestPty("xterm", 60, 25);
+            channel.requestShell();
+            checkTrue("the server grants a pty and starts a shell", true);
+
+            channel.write(Utf8.encode("echo be''rryssh-works; stty size; exit\n"));
+
+            StringBuffer output = new StringBuffer();
+            byte[] buffer = new byte[4096];
+            for (;;) {
+                int n = channel.read(buffer, 0, buffer.length);
+                if (n < 0) {
+                    break;
+                }
+                output.append(Utf8.decode(buffer, 0, n));
+            }
+            String text = output.toString();
+
+            // Written split so the echoed command line cannot be mistaken for
+            // the shell's output: only the shell can produce it joined.
+            checkTrue("the shell runs a command and returns its output",
+                text.indexOf("berryssh-works") >= 0);
+
+            // The pty really carries the dimensions we asked for, rather than
+            // the request merely being accepted.
+            checkTrue("the pty is the 60x25 we asked for", text.indexOf("25 60") >= 0);
+
+            channel.close();
+            System.out.println("        shell exit status " + channel.exitStatus());
         } finally {
             socket.close();
         }

--- a/ssh/src/berryssh/protocol/Channel.java
+++ b/ssh/src/berryssh/protocol/Channel.java
@@ -1,0 +1,349 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+/**
+ * A session channel: a pty, a shell, and the bytes going both ways.
+ * RFC 4254.
+ *
+ * The flow control is the part that has to be right rather than merely
+ * present. Each side advertises a window and may not send past it; a client
+ * that forgets to top its window up receives a few tens of kilobytes and then
+ * hangs for good, which reads as a network fault rather than as a bug here.
+ *
+ * Only one channel is opened, because the client does one thing. That keeps
+ * dispatch to a single recipient check rather than a table, and it is the
+ * reason a message for another channel is an error instead of something to
+ * route.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Channel {
+
+    /**
+     * 2 MB. Generous on purpose: every refill is a packet, and on this link the
+     * round trip costs far more than the memory does — the device measured
+     * ~357 MB of free heap.
+     */
+    private static final int INITIAL_WINDOW = 2 * 1024 * 1024;
+
+    /** Below half, the window is topped back up. */
+    private static final int REFILL_AT = INITIAL_WINDOW / 2;
+
+    private static final int MAX_PACKET = 32 * 1024;
+
+    /** Our channel number. With one channel it can be a constant. */
+    private static final int LOCAL_ID = 0;
+
+    private final Connection connection;
+
+    private int remoteId;
+    private long remoteWindow;
+    private int remoteMaxPacket;
+    private long localWindow = INITIAL_WINDOW;
+
+    private byte[] pending = new byte[0];
+    private int pendingAt;
+
+    private boolean eof;
+    private boolean closed;
+    private int exitStatus = -1;
+
+    private Channel(Connection connection) {
+        this.connection = connection;
+    }
+
+    /** Opens a session channel and waits for the server to confirm it. */
+    public static Channel openSession(Connection connection) throws IOException {
+        Channel channel = new Channel(connection);
+
+        WireWriter w = new WireWriter(64);
+        w.writeByte(Message.CHANNEL_OPEN);
+        w.writeAsciiString("session");
+        w.writeUint32(LOCAL_ID);
+        w.writeUint32(INITIAL_WINDOW);
+        w.writeUint32(MAX_PACKET);
+        connection.transport().writePacket(w.toByteArray());
+
+        for (;;) {
+            byte[] payload = connection.transport().readMessage();
+            int type = payload[0] & 0xff;
+            WireReader r = new WireReader(payload);
+            r.readByte();
+
+            if (type == Message.CHANNEL_OPEN_CONFIRMATION) {
+                r.readUint32();
+                channel.remoteId = (int) r.readUint32();
+                channel.remoteWindow = r.readUint32();
+                channel.remoteMaxPacket = (int) r.readUint32();
+                return channel;
+            }
+            if (type == Message.CHANNEL_OPEN_FAILURE) {
+                r.readUint32();
+                long reason = r.readUint32();
+                throw new SshException("the server refused a session channel ("
+                    + reason + "): " + r.readAsciiString());
+            }
+            channel.handleOther(type, payload);
+        }
+    }
+
+    /**
+     * Asks for a pseudo-terminal.
+     *
+     * The pixel dimensions are sent as zero, which tells the server to work
+     * from the character grid. That is the honest answer here: the terminal is
+     * a bitmap font on a canvas, so its pixel size says nothing a program could
+     * use.
+     */
+    public void requestPty(String term, int columns, int rows) throws IOException {
+        WireWriter w = new WireWriter(64);
+        w.writeByte(Message.CHANNEL_REQUEST);
+        w.writeUint32(remoteId);
+        w.writeAsciiString("pty-req");
+        w.writeBoolean(true);
+        w.writeAsciiString(term);
+        w.writeUint32(columns);
+        w.writeUint32(rows);
+        w.writeUint32(0);
+        w.writeUint32(0);
+        // Terminal modes, as opcode-value pairs ended by TTY_OP_END. Empty:
+        // the server's defaults are what a shell would get locally.
+        w.writeString(new byte[] { 0 });
+        connection.transport().writePacket(w.toByteArray());
+        awaitReply("pty-req");
+    }
+
+    public void requestShell() throws IOException {
+        WireWriter w = new WireWriter(32);
+        w.writeByte(Message.CHANNEL_REQUEST);
+        w.writeUint32(remoteId);
+        w.writeAsciiString("shell");
+        w.writeBoolean(true);
+        connection.transport().writePacket(w.toByteArray());
+        awaitReply("shell");
+    }
+
+    /** Tells the server the terminal changed size. RFC 4254 sends no reply to this. */
+    public void windowChange(int columns, int rows) throws IOException {
+        WireWriter w = new WireWriter(48);
+        w.writeByte(Message.CHANNEL_REQUEST);
+        w.writeUint32(remoteId);
+        w.writeAsciiString("window-change");
+        w.writeBoolean(false);
+        w.writeUint32(columns);
+        w.writeUint32(rows);
+        w.writeUint32(0);
+        w.writeUint32(0);
+        connection.transport().writePacket(w.toByteArray());
+    }
+
+    /**
+     * Sends data, splitting it to the server's maximum packet size and waiting
+     * when its window is full.
+     */
+    public void write(byte[] data, int offset, int length) throws IOException {
+        while (length > 0) {
+            while (remoteWindow == 0) {
+                // Nothing to do but read: only the server can reopen its window.
+                pump();
+            }
+            int take = length;
+            if (take > remoteMaxPacket) {
+                take = remoteMaxPacket;
+            }
+            if (take > remoteWindow) {
+                take = (int) remoteWindow;
+            }
+
+            WireWriter w = new WireWriter(take + 16);
+            w.writeByte(Message.CHANNEL_DATA);
+            w.writeUint32(remoteId);
+            w.writeString(data, offset, take);
+            connection.transport().writePacket(w.toByteArray());
+
+            remoteWindow -= take;
+            offset += take;
+            length -= take;
+        }
+    }
+
+    public void write(byte[] data) throws IOException {
+        write(data, 0, data.length);
+    }
+
+    /**
+     * Reads what the server has sent, blocking until there is some.
+     *
+     * @return the number of bytes read, or -1 once the server has finished
+     */
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+        while (pendingAt == pending.length) {
+            if (eof || closed) {
+                return -1;
+            }
+            pump();
+        }
+        int take = pending.length - pendingAt;
+        if (take > length) {
+            take = length;
+        }
+        System.arraycopy(pending, pendingAt, buffer, offset, take);
+        pendingAt += take;
+
+        // Credit the server for what has actually been consumed, not for what
+        // arrived. Topping up on arrival would advertise room we do not have.
+        localWindow -= take;
+        if (localWindow <= REFILL_AT) {
+            long top = INITIAL_WINDOW - localWindow;
+            WireWriter w = new WireWriter(16);
+            w.writeByte(Message.CHANNEL_WINDOW_ADJUST);
+            w.writeUint32(remoteId);
+            w.writeUint32(top);
+            connection.transport().writePacket(w.toByteArray());
+            localWindow += top;
+        }
+        return take;
+    }
+
+    /** True once the server has sent EOF or closed the channel. */
+    public boolean isFinished() {
+        return (eof || closed) && pendingAt == pending.length;
+    }
+
+    /**
+     * The shell's exit status, or -1 if none was seen.
+     *
+     * Only captured if it arrives before EOF. Reading stops at EOF because
+     * that is when the server has promised there is no more data, and carrying
+     * on until CLOSE would hang against a server that half-closes and keeps the
+     * channel open for ours. A terminal does not act on the status, so the
+     * trade favours never hanging.
+     */
+    public int exitStatus() {
+        return exitStatus;
+    }
+
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        WireWriter w = new WireWriter(16);
+        w.writeByte(Message.CHANNEL_CLOSE);
+        w.writeUint32(remoteId);
+        connection.transport().writePacket(w.toByteArray());
+        closed = true;
+    }
+
+    /** Reads and dispatches exactly one message. */
+    private void pump() throws IOException {
+        byte[] payload = connection.transport().readMessage();
+        int type = payload[0] & 0xff;
+
+        if (type == Message.CHANNEL_DATA) {
+            WireReader r = new WireReader(payload);
+            r.readByte();
+            checkRecipient(r.readUint32());
+            append(r.readString());
+            return;
+        }
+        if (type == Message.CHANNEL_EXTENDED_DATA) {
+            WireReader r = new WireReader(payload);
+            r.readByte();
+            checkRecipient(r.readUint32());
+            r.readUint32();
+            // With a pty the server merges stderr into the terminal stream
+            // anyway, so anything arriving here belongs in the same place: a
+            // terminal that hid it would lose error messages entirely.
+            append(r.readString());
+            return;
+        }
+        handleOther(type, payload);
+    }
+
+    private void handleOther(int type, byte[] payload) throws IOException {
+        WireReader r = new WireReader(payload);
+        r.readByte();
+
+        if (type == Message.CHANNEL_WINDOW_ADJUST) {
+            checkRecipient(r.readUint32());
+            remoteWindow += r.readUint32();
+            return;
+        }
+        if (type == Message.CHANNEL_EOF) {
+            eof = true;
+            return;
+        }
+        if (type == Message.CHANNEL_CLOSE) {
+            closed = true;
+            return;
+        }
+        if (type == Message.CHANNEL_REQUEST) {
+            r.readUint32();
+            String request = r.readAsciiString();
+            boolean wantReply = r.readBoolean();
+            if ("exit-status".equals(request)) {
+                exitStatus = (int) r.readUint32();
+            }
+            if (wantReply) {
+                // We implement no channel requests, and saying so is required:
+                // a server waiting on a reply that never comes stalls.
+                WireWriter w = new WireWriter(16);
+                w.writeByte(Message.CHANNEL_FAILURE);
+                w.writeUint32(remoteId);
+                connection.transport().writePacket(w.toByteArray());
+            }
+            return;
+        }
+        if (type == Message.GLOBAL_REQUEST) {
+            r.readAsciiString();
+            if (r.readBoolean()) {
+                WireWriter w = new WireWriter(8);
+                w.writeByte(Message.REQUEST_FAILURE);
+                connection.transport().writePacket(w.toByteArray());
+            }
+            return;
+        }
+        throw new SshException("unexpected " + Message.name(type) + " on a session channel");
+    }
+
+    private void awaitReply(String request) throws IOException {
+        for (;;) {
+            byte[] payload = connection.transport().readMessage();
+            int type = payload[0] & 0xff;
+            if (type == Message.CHANNEL_SUCCESS) {
+                return;
+            }
+            if (type == Message.CHANNEL_FAILURE) {
+                throw new SshException("the server refused " + request);
+            }
+            // Data can arrive before the reply does; it is not lost.
+            if (type == Message.CHANNEL_DATA || type == Message.CHANNEL_EXTENDED_DATA) {
+                WireReader r = new WireReader(payload);
+                r.readByte();
+                checkRecipient(r.readUint32());
+                if (type == Message.CHANNEL_EXTENDED_DATA) {
+                    r.readUint32();
+                }
+                append(r.readString());
+                continue;
+            }
+            handleOther(type, payload);
+        }
+    }
+
+    private void checkRecipient(long recipient) throws IOException {
+        if (recipient != LOCAL_ID) {
+            throw new SshException("message for channel " + recipient + ", which is not ours");
+        }
+    }
+
+    private void append(byte[] data) {
+        int left = pending.length - pendingAt;
+        byte[] combined = new byte[left + data.length];
+        System.arraycopy(pending, pendingAt, combined, 0, left);
+        System.arraycopy(data, 0, combined, left, data.length);
+        pending = combined;
+        pendingAt = 0;
+    }
+}


### PR DESCRIPTION
Implement the session channel, pty-req and shell

RFC 4254. With this the client works: it authenticates against OpenSSH 9.2p1,
takes a pty, runs a shell and reads back what it printed. The test asks the
shell for `stty size` and gets `25 60`, so the pty really is the size the
device's 8x14 cell gives on a 480x360 canvas rather than the request merely
having been accepted.

That test is the one worth having. Everything underneath has to be right at the
same time — a wrong exchange hash, a swapped cipher key, a padding rule off by
eight, a mis-encoded password, a forgotten window update — and none of them can
be covered for by another.

Flow control is the part that has to be correct rather than merely present. The
window is credited for what has been consumed, not for what arrived: topping up
on arrival would advertise room we do not have. A client that forgets this
receives a few tens of kilobytes and then hangs for good, which reads as a
network fault rather than as a bug in the client.

Two smaller decisions worth recording. Extended data goes into the same stream
as ordinary data, because with a pty the server merges stderr into the terminal
anyway and a terminal that hid it would lose error messages outright. And a
channel or global request that wants a reply always gets one, even though we
implement no requests: a server left waiting on a reply that never comes
stalls.

Reading stops at EOF rather than at CLOSE, which means an exit status sent
after EOF is not seen. That is deliberate — carrying on to CLOSE would hang
against a server that half-closes and keeps the channel open for our data, and
a terminal does not act on the status.

Closes #8.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

