### PR TITLE
Implement host key trust and known-hosts storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ against vectors computed outside it. 49 in total.
 **Transport**: RFC 4251 §5 for the wire types, RFC 4253 §6 for the packet
 framing and §7.1 for algorithm negotiation, RFC 8731 §3 for the exchange hash
 and RFC 4253 §7.2 for key derivation, plus base64, host key parsing, the
-version exchange, the chacha20-poly1305 packet layer, UTF-8 and the paths
-that have to reject malformed input. 93 in total. They run under a Turkish default locale, which is the device's own and
+version exchange, the chacha20-poly1305 packet layer, UTF-8, host key trust
+and the paths that have to reject malformed input. 99 in total. They run under a Turkish default locale, which is the device's own and
 the setting most likely to break protocol code without raising an error
 anywhere.
 
@@ -151,6 +151,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] `chacha20-poly1305@openssh.com` packet layer, and an encrypted handshake
 - [x] User authentication: `none`, `password`, `publickey` with Ed25519
 - [x] Channels, `pty-req`, shell — a working session against OpenSSH 9.2p1
+- [x] Host key trust, stored in RMS
 - [ ] Terminal emulation and UI
 
 ## Prior art

--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -3,6 +3,7 @@ import berryssh.protocol.Base64;
 import berryssh.protocol.HostKey;
 import berryssh.protocol.KexInit;
 import berryssh.protocol.KeyExchange;
+import berryssh.protocol.KnownHosts;
 import berryssh.protocol.PacketCipher;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.SshException;
@@ -57,6 +58,7 @@ public class TransportTests {
         packetCipherVectors();
         encryptedFraming();
         utf8Vectors();
+        knownHostsPolicy();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -697,6 +699,62 @@ public class TransportTests {
             "a�b".equals(Utf8.decode(hex("61ff62"))));
         checkTrue("a truncated sequence at the end does not run off the array",
             Utf8.decode(hex("61c3")).length() == 2);
+    }
+
+    /**
+     * The trust decision, away from RMS.
+     *
+     * This is the half of host authentication the signature check cannot do.
+     * Verifying the signature proves the server holds the key it showed us;
+     * only this says whether it is the same key as last time.
+     */
+    private static void knownHostsPolicy() {
+        byte[] blobA = hex("0000000b7373682d6564323535313900000020"
+            + "2ff01c2270598befd06f04f4c80df20da07c5a0834d13e327bc1c5eefd9bcbbf");
+        byte[] blobB = hex("0000000b7373682d6564323535313900000020"
+            + "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025");
+
+        try {
+            HostKey keyA = HostKey.parse(blobA);
+            HostKey keyB = HostKey.parse(blobB);
+            MemoryStore store = new MemoryStore();
+
+            checkTrue("an unseen host is unknown",
+                KnownHosts.check(store, "example.org", 22, keyA) == KnownHosts.UNKNOWN);
+
+            KnownHosts.accept(store, "example.org", 22, keyA);
+            checkTrue("an accepted host matches next time",
+                KnownHosts.check(store, "example.org", 22, keyA) == KnownHosts.MATCHED);
+
+            checkTrue("a different key on the same host is a mismatch",
+                KnownHosts.check(store, "example.org", 22, keyB) == KnownHosts.CHANGED);
+
+            // The port is part of the identity, as it is in OpenSSH's
+            // known_hosts: two servers behind one address are two hosts.
+            checkTrue("the same address on another port is a different host",
+                KnownHosts.check(store, "example.org", 2222, keyA) == KnownHosts.UNKNOWN);
+
+            checkTrue("the first-contact prompt carries the comparable fingerprint",
+                KnownHosts.firstContactPrompt("example.org", 22, keyA)
+                    .indexOf("SHA256:9tqjakW/Ia6U4hT3VgAv8EXXCxC1d3ez9mr5qjVTRZs") >= 0);
+            checkTrue("the mismatch warning is a statement, not a question",
+                KnownHosts.mismatchWarning("example.org", 22, keyB).indexOf('?') < 0);
+        } catch (IOException e) {
+            fail("known hosts threw " + e);
+        }
+    }
+
+    /** Stands in for RMS, which exists only on the device. */
+    private static final class MemoryStore implements KnownHosts.Store {
+        private final java.util.Hashtable entries = new java.util.Hashtable();
+
+        public byte[] lookup(String host, int port) {
+            return (byte[]) entries.get(host + ":" + port);
+        }
+
+        public void store(String host, int port, byte[] blob) {
+            entries.put(host + ":" + port, blob);
+        }
     }
 
     private static byte[] slice(byte[] b, int offset, int length) {

--- a/ssh/src/berryssh/device/RecordStoreHostKeys.java
+++ b/ssh/src/berryssh/device/RecordStoreHostKeys.java
@@ -1,0 +1,124 @@
+package berryssh.device;
+
+import java.io.IOException;
+
+import javax.microedition.rms.RecordEnumeration;
+import javax.microedition.rms.RecordStore;
+import javax.microedition.rms.RecordStoreException;
+
+import berryssh.protocol.KnownHosts;
+import berryssh.protocol.SshException;
+import berryssh.protocol.WireReader;
+import berryssh.protocol.WireWriter;
+
+/**
+ * Host key storage in RMS, the record store every MIDP implementation has.
+ *
+ * RMS is MIDP rather than RIM, so it needs no signature — which is the whole
+ * reason it is usable here. Records are app-private, so a key written by this
+ * MIDlet cannot be read or replaced by another one.
+ *
+ * This is the one class in the protocol path that cannot run on the host, which
+ * is why the decision it serves lives in {@link KnownHosts} instead of in here.
+ * What is left is lookup and append, and it still compiles against the CLDC and
+ * MIDP bootclasspath like everything else.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class RecordStoreHostKeys implements KnownHosts.Store {
+
+    private static final String STORE_NAME = "berryssh_hostkeys";
+
+    public byte[] lookup(String host, int port) throws IOException {
+        RecordStore store = open();
+        try {
+            RecordEnumeration records = store.enumerateRecords(null, null, false);
+            String wanted = key(host, port);
+            while (records.hasNextElement()) {
+                byte[] record = records.nextRecord();
+                WireReader r = new WireReader(record);
+                if (wanted.equals(r.readAsciiString())) {
+                    return r.readString();
+                }
+            }
+            return null;
+        } catch (RecordStoreException e) {
+            throw new SshException("could not read the host key store: " + e.getMessage());
+        } finally {
+            close(store);
+        }
+    }
+
+    public void store(String host, int port, byte[] blob) throws IOException {
+        RecordStore store = open();
+        try {
+            // Any existing record for this host goes first. A store that grew a
+            // second entry would make which key is trusted depend on
+            // enumeration order.
+            RecordEnumeration records = store.enumerateRecords(null, null, false);
+            String wanted = key(host, port);
+            while (records.hasNextElement()) {
+                int id = records.nextRecordId();
+                WireReader r = new WireReader(store.getRecord(id));
+                if (wanted.equals(r.readAsciiString())) {
+                    store.deleteRecord(id);
+                }
+            }
+
+            WireWriter w = new WireWriter(128);
+            w.writeAsciiString(wanted);
+            w.writeString(blob);
+            byte[] record = w.toByteArray();
+            store.addRecord(record, 0, record.length);
+        } catch (RecordStoreException e) {
+            throw new SshException("could not write the host key store: " + e.getMessage());
+        } finally {
+            close(store);
+        }
+    }
+
+    /** Removes a host, so a genuinely rebuilt server can be accepted afresh. */
+    public void forget(String host, int port) throws IOException {
+        RecordStore store = open();
+        try {
+            RecordEnumeration records = store.enumerateRecords(null, null, false);
+            String wanted = key(host, port);
+            while (records.hasNextElement()) {
+                int id = records.nextRecordId();
+                WireReader r = new WireReader(store.getRecord(id));
+                if (wanted.equals(r.readAsciiString())) {
+                    store.deleteRecord(id);
+                }
+            }
+        } catch (RecordStoreException e) {
+            throw new SshException("could not update the host key store: " + e.getMessage());
+        } finally {
+            close(store);
+        }
+    }
+
+    /**
+     * The port is part of the identity: two servers on one address are two
+     * different hosts, and OpenSSH's known_hosts treats them that way too.
+     */
+    private static String key(String host, int port) {
+        return host + ":" + port;
+    }
+
+    private static RecordStore open() throws IOException {
+        try {
+            return RecordStore.openRecordStore(STORE_NAME, true);
+        } catch (RecordStoreException e) {
+            throw new SshException("could not open the host key store: " + e.getMessage());
+        }
+    }
+
+    private static void close(RecordStore store) {
+        try {
+            store.closeRecordStore();
+        } catch (RecordStoreException e) {
+            // Nothing useful to do: the records are already written, and
+            // throwing here would replace a real error with a cosmetic one.
+        }
+    }
+}

--- a/ssh/src/berryssh/protocol/KnownHosts.java
+++ b/ssh/src/berryssh/protocol/KnownHosts.java
@@ -1,0 +1,95 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+/**
+ * Whether the host key we were shown is the one we saw last time.
+ *
+ * Verifying the signature (see {@link KeyExchange}) proves the server holds the
+ * private half of the key it presented. It says nothing at all about whether
+ * that server is the one the user meant to reach — anyone in the path can
+ * present a key they hold. This is the half that answers that, and without it
+ * the handshake protects against a passive eavesdropper only.
+ *
+ * The policy lives here and the storage lives behind {@link Store}, because RMS
+ * exists only on the device: splitting them means the decision that matters can
+ * be tested on the host, where getting it wrong is cheap to find.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class KnownHosts {
+
+    /** No key on record for this host: the user has to be asked. */
+    public static final int UNKNOWN = 0;
+
+    /** The key matches what was stored. Carry on. */
+    public static final int MATCHED = 1;
+
+    /** A different key. Refuse; do not offer to continue. */
+    public static final int CHANGED = 2;
+
+    /** Where host keys are kept. Implemented over RMS on the device. */
+    public interface Store {
+        /** The stored key blob for this host, or null. */
+        byte[] lookup(String host, int port) throws IOException;
+
+        void store(String host, int port, byte[] blob) throws IOException;
+    }
+
+    private KnownHosts() {
+    }
+
+    public static int check(Store store, String host, int port, HostKey key) throws IOException {
+        byte[] known = store.lookup(host, port);
+        if (known == null) {
+            return UNKNOWN;
+        }
+        return equalBytes(known, key.blob()) ? MATCHED : CHANGED;
+    }
+
+    /** Records a key the user accepted. */
+    public static void accept(Store store, String host, int port, HostKey key) throws IOException {
+        store.store(host, port, key.blob());
+    }
+
+    /**
+     * What to show a user who has never seen this host.
+     *
+     * The fingerprint is the SHA-256 base64 form, which is exactly what
+     * `ssh-keygen -lf` prints on the server — a fingerprint in a format nothing
+     * else produces is one nobody can actually check against anything.
+     */
+    public static String firstContactPrompt(String host, int port, HostKey key) {
+        return "The authenticity of " + host + ":" + port + " cannot be established.\n"
+            + "ED25519 key fingerprint is " + key.fingerprint() + ".\n"
+            + "Compare it against `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`"
+            + " on the server before accepting.";
+    }
+
+    /**
+     * What to show when the key has changed.
+     *
+     * Deliberately not a question. A mismatch is either an attack or an
+     * administrative change the user knows about, and in both cases the right
+     * move is to stop and go and find out — an "accept anyway" button turns the
+     * one moment this check exists for into a button press.
+     */
+    public static String mismatchWarning(String host, int port, HostKey key) {
+        return "THE HOST KEY FOR " + host + ":" + port + " HAS CHANGED.\n"
+            + "It is now " + key.fingerprint() + ".\n"
+            + "Someone may be intercepting this connection. If the server was"
+            + " genuinely rebuilt, remove the stored key and connect again.";
+    }
+
+    private static boolean equalBytes(byte[] a, byte[] b) {
+        if (a.length != b.length) {
+            return false;
+        }
+        for (int i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Implement host key trust and known-hosts storage

Verifying the host key signature proves the server holds the private half of
the key it presented. It says nothing about whether that server is the one the
user meant to reach — anyone in the path can present a key they hold. This is
the half that answers that, and without it the handshake protects against a
passive eavesdropper only.

The policy is separated from the storage because RMS exists only on the device.
Splitting them puts the decision that actually matters where it can be tested
on the host, and leaves lookup-and-append behind an interface. RMS is MIDP
rather than RIM, so it needs no signature, and its records are app-private.

The mismatch message is deliberately a statement rather than a question, and
there is no accept-anyway path. A changed key is either an attack or an
administrative change the user knows about; in both cases the right move is to
stop and find out. Offering a button turns the one moment this check exists for
into a button press. A rebuilt server is handled by forgetting the host
explicitly, which is a thing you have to mean.

The port is part of the host's identity, as it is in OpenSSH's known_hosts: two
servers behind one address are two hosts. Storing a key replaces any existing
entry rather than appending, so which key is trusted can never come to depend
on enumeration order.

Fingerprints are the SHA-256 base64 form `ssh-keygen -lf` prints, so what the
handset shows can be compared with the server character for character.

Closes #12.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

