### PR TITLE
Add the keyboard mapping and the MIDlet that ties everything together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ lib/*.jar
 
 # macOS
 .DS_Store
+
+# Build output
+/out/
+/classes/
+/classes-pv/

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ No BlackBerry SDK is involved. Dependencies are fetched, not vendored:
 
 ```sh
 lib/fetch.sh          # MIDP/CLDC API stubs and ProGuard, from Maven Central
-spike1/build.sh       # -> spike1/out/Probe.jad + Probe.jar
+./build.sh            # -> out/berryssh.jad + berryssh.jar
 ```
 
 - **API stubs**: microemu's `cldcapi11` / `midpapi20`
@@ -70,7 +70,7 @@ Plain HTTP is deliberate: the OS 7 browser's trust store predates every
 currently issued CA.
 
 ```sh
-python3 tools/ota_server.py spike1/out
+python3 tools/ota_server.py out
 ```
 
 Then open the printed URL in the device's native browser, over Wi-Fi.
@@ -133,7 +133,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 ## Layout
 
     lib/            dependency fetcher
-    ssh/src/        the client library
+    ssh/src/        the client library and the MIDlet
     spike1/         device capability probe
     ssh/res/        font atlases
     spike2/         test vectors, run on the host
@@ -154,7 +154,8 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] Channels, `pty-req`, shell — a working session against OpenSSH 9.2p1
 - [x] Host key trust, stored in RMS
 - [x] VT320 terminal emulation, and a bitmap font renderer
-- [ ] Keyboard mapping, and the MIDlet that ties it together
+- [x] A MIDlet that connects, authenticates and runs a shell
+- [ ] Keyboard mapping confirmed against the hardware's real key codes
 
 ## Prior art
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Build the berryssh MIDlet: javac (JDK 8, targeting 1.3) -> preverify -> jar -> jad.
+#
+# Compiles in a container because CLDC 1.1 wants class file version 47 and the
+# host JDK cannot emit anything that old. The API stubs are microemu's
+# repackaged cldcapi11/midpapi20, so no BlackBerry JDE is involved anywhere —
+# and since nothing here touches a RIM API, the result needs no code signature.
+#
+#   ./build.sh            -> out/berryssh.jar + out/berryssh.jad
+#   tools/ota_server.py out
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+NAME=berryssh
+VENDOR="berryssh"
+VERSION=0.1.0
+MIDLET_CLASS=berryssh.device.BerrysshMIDlet
+
+OUT=out
+JAR="$OUT/$NAME.jar"
+JAD="$OUT/$NAME.jad"
+
+# OrbStack's socket, and a throwaway docker config so the host's broken Docker
+# Desktop credential helper is not consulted.
+export DOCKER_HOST="${DOCKER_HOST:-unix://$HOME/.orbstack/run/docker.sock}"
+DOCKER_CONFIG="$(mktemp -d)"; export DOCKER_CONFIG
+printf '{}' > "$DOCKER_CONFIG/config.json"
+trap 'rm -rf "$DOCKER_CONFIG"' EXIT
+
+rm -rf "$OUT" classes classes-pv
+mkdir -p "$OUT" classes
+
+echo "==> compiling (source/target 1.3)"
+# javac's exit status decides this, not the presence of some class file: a
+# partial failure still leaves earlier packages on disk.
+if ! output=$(docker run --rm \
+    -v "$PWD:/work" -v "$PWD/lib:/libs:ro" -w /work \
+    eclipse-temurin:8-jdk \
+    javac -source 1.3 -target 1.3 -nowarn \
+          -bootclasspath /libs/cldcapi11.jar:/libs/midpapi20.jar \
+          -d classes $(find ssh/src -name '*.java' | tr '\n' ' ') 2>&1); then
+    echo "$output" >&2
+    echo "the client did not compile under CLDC constraints" >&2
+    exit 1
+fi
+echo "$output" | grep -v 'obsolete\|deprecat\|warning' || true
+
+echo "==> class file version"
+docker run --rm -v "$PWD:/work" -w /work eclipse-temurin:8-jdk \
+    javap -verbose -cp classes "$MIDLET_CLASS" 2>/dev/null | grep -m1 'major version' || true
+
+# CLDC's verifier needs StackMap attributes baked in ahead of time; without them
+# the device rejects the suite with "907 Invalid JAR / missing stack map".
+# ProGuard's -microedition mode emits them, so no native preverifier is needed.
+echo "==> preverifying (CLDC StackMap)"
+rm -rf classes-pv && mkdir -p classes-pv
+java -cp lib/proguard.jar proguard.ProGuard \
+    -injars classes -outjars classes-pv \
+    -libraryjars lib/cldcapi11.jar -libraryjars lib/midpapi20.jar \
+    -dontshrink -dontobfuscate -dontoptimize -microedition \
+    -keep 'public class * extends javax.microedition.midlet.MIDlet' \
+    > "$OUT/proguard.log" 2>&1
+
+if [ -z "$(find classes-pv -name '*.class' -print -quit)" ]; then
+    echo "preverification produced no classes; see $OUT/proguard.log" >&2
+    exit 1
+fi
+
+echo "==> packaging jar"
+cat > "$OUT/manifest.mf" <<EOF
+MIDlet-Name: $NAME
+MIDlet-Version: $VERSION
+MIDlet-Vendor: $VENDOR
+MIDlet-1: $NAME,,$MIDLET_CLASS
+MicroEdition-Profile: MIDP-2.0
+MicroEdition-Configuration: CLDC-1.1
+EOF
+
+# The font atlases ride in the jar and are loaded with getResourceAsStream.
+docker run --rm -v "$PWD:/work" -w /work eclipse-temurin:8-jdk \
+    jar cfm "$JAR" "$OUT/manifest.mf" -C classes-pv . -C ssh/res .
+
+JAR_SIZE=$(stat -f%z "$JAR" 2>/dev/null || stat -c%s "$JAR")
+
+# The descriptor must repeat the MIDlet-* attributes and state the jar's exact
+# size; a mismatch is one of the ways an OTA install fails with no useful error.
+cat > "$JAD" <<EOF
+MIDlet-Name: $NAME
+MIDlet-Version: $VERSION
+MIDlet-Vendor: $VENDOR
+MIDlet-1: $NAME,,$MIDLET_CLASS
+MicroEdition-Profile: MIDP-2.0
+MicroEdition-Configuration: CLDC-1.1
+MIDlet-Jar-URL: $NAME.jar
+MIDlet-Jar-Size: $JAR_SIZE
+EOF
+
+rm -f "$OUT/manifest.mf"
+echo "==> built $JAR ($JAR_SIZE bytes) + $JAD"

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -1,0 +1,287 @@
+package berryssh.device;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import javax.microedition.io.Connector;
+import javax.microedition.io.SocketConnection;
+import javax.microedition.lcdui.Alert;
+import javax.microedition.lcdui.AlertType;
+import javax.microedition.lcdui.Command;
+import javax.microedition.lcdui.CommandListener;
+import javax.microedition.lcdui.Display;
+import javax.microedition.lcdui.Displayable;
+import javax.microedition.lcdui.Form;
+import javax.microedition.lcdui.TextField;
+import javax.microedition.midlet.MIDlet;
+
+import berryssh.crypto.EntropyPool;
+import berryssh.protocol.Channel;
+import berryssh.protocol.Connection;
+import berryssh.protocol.HostKey;
+import berryssh.protocol.KnownHosts;
+import berryssh.protocol.UserAuth;
+import berryssh.protocol.Utf8;
+import berryssh.terminal.BitmapFont;
+import berryssh.terminal.VT320;
+
+/**
+ * The application.
+ *
+ * Everything below this class is plain MIDP and CLDC and touches no RIM API,
+ * which is the whole point: code that never reaches a protected API needs no
+ * BlackBerry signature, and the authority that issued those no longer exists.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class BerrysshMIDlet extends MIDlet implements CommandListener {
+
+    private static final String FONT = "/fonts/BVSM8x14.png";
+    private static final int CELL_WIDTH = 8;
+    private static final int CELL_HEIGHT = 14;
+
+    private final Command connect = new Command("Connect", Command.OK, 1);
+    private final Command quit = new Command("Quit", Command.EXIT, 2);
+    private final Command control = new Command("Ctrl", Command.SCREEN, 1);
+    private final Command escape = new Command("Esc", Command.SCREEN, 2);
+    private final Command disconnect = new Command("Disconnect", Command.STOP, 3);
+
+    private Display display;
+    private Form setup;
+    private TextField hostField;
+    private TextField portField;
+    private TextField userField;
+    private TextField passwordField;
+
+    private TerminalCanvas canvas;
+    private Keyboard keyboard;
+    private VT320 terminal;
+
+    private final EntropyPool random = new EntropyPool();
+    private final RecordStoreHostKeys hostKeys = new RecordStoreHostKeys();
+
+    private SocketConnection socket;
+    private Channel channel;
+    private volatile boolean running;
+
+    protected void startApp() {
+        if (display != null) {
+            return;
+        }
+        display = Display.getDisplay(this);
+
+        // Seeding costs about a tenth of a second and needs doing before any
+        // key material is asked for. Doing it here rather than at connect time
+        // spends it while the user is still typing a hostname.
+        new Thread(new Runnable() {
+            public void run() {
+                random.seed();
+            }
+        }).start();
+
+        setup = new Form("berryssh");
+        hostField = new TextField("Host", "", 64, TextField.URL);
+        portField = new TextField("Port", "22", 5, TextField.NUMERIC);
+        userField = new TextField("User", "", 32, TextField.ANY);
+        passwordField = new TextField("Password", "", 64, TextField.PASSWORD);
+        setup.append(hostField);
+        setup.append(portField);
+        setup.append(userField);
+        setup.append(passwordField);
+        setup.addCommand(connect);
+        setup.addCommand(quit);
+        setup.setCommandListener(this);
+        display.setCurrent(setup);
+    }
+
+    protected void pauseApp() {
+    }
+
+    protected void destroyApp(boolean unconditional) {
+        shutdown();
+    }
+
+    public void commandAction(Command command, Displayable from) {
+        if (command == quit) {
+            shutdown();
+            notifyDestroyed();
+            return;
+        }
+        if (command == connect) {
+            startSession();
+            return;
+        }
+        if (command == control) {
+            keyboard.toggleControl();
+            canvas.repaint();
+            return;
+        }
+        if (command == escape) {
+            keyboard.sendEscape();
+            return;
+        }
+        if (command == disconnect) {
+            shutdown();
+            display.setCurrent(setup);
+        }
+    }
+
+    private void startSession() {
+        final String host = hostField.getString().trim();
+        final int port = parsePort(portField.getString());
+        final String user = userField.getString().trim();
+        final String password = passwordField.getString();
+
+        if (host.length() == 0 || user.length() == 0) {
+            show("A host and a user are needed.", AlertType.WARNING, setup);
+            return;
+        }
+
+        BitmapFont font;
+        try {
+            font = BitmapFont.load(FONT, CELL_WIDTH, CELL_HEIGHT);
+        } catch (IOException e) {
+            show("The font atlas is missing: " + e.getMessage(), AlertType.ERROR, setup);
+            return;
+        }
+
+        canvas = new TerminalCanvas(font);
+        canvas.addCommand(control);
+        canvas.addCommand(escape);
+        canvas.addCommand(disconnect);
+        canvas.setCommandListener(this);
+        canvas.setStatus("connecting to " + host + "...");
+        display.setCurrent(canvas);
+
+        // Networking must not run on the event thread: on this platform the
+        // first socket open can block for seconds while the radio comes up, and
+        // a blocked event thread is a frozen screen.
+        running = true;
+        new Thread(new Runnable() {
+            public void run() {
+                runSession(host, port, user, password);
+            }
+        }).start();
+    }
+
+    private void runSession(String host, int port, String user, String password) {
+        try {
+            random.seed();
+
+            socket = (SocketConnection) Connector.open(
+                "socket://" + host + ":" + port, Connector.READ_WRITE);
+            InputStream in = socket.openInputStream();
+            OutputStream out = socket.openOutputStream();
+
+            Connection connection = new Connection(in, out, random);
+            HostKey key = connection.handshake();
+
+            int trust = KnownHosts.check(hostKeys, host, port, key);
+            if (trust == KnownHosts.CHANGED) {
+                // Not a question. See KnownHosts for why there is no way past
+                // this short of forgetting the host deliberately.
+                fail(KnownHosts.mismatchWarning(host, port, key));
+                return;
+            }
+            if (trust == KnownHosts.UNKNOWN) {
+                // Trust on first use. The fingerprint is shown in the form
+                // ssh-keygen prints so it can actually be compared.
+                canvas.setStatus(key.fingerprint());
+                KnownHosts.accept(hostKeys, host, port, key);
+            }
+
+            UserAuth auth = new UserAuth(connection, user);
+            auth.begin();
+            auth.queryMethods();
+            if (!auth.password(password).succeeded()) {
+                fail("Authentication failed.");
+                return;
+            }
+
+            final Channel session = Channel.openSession(connection);
+            channel = session;
+
+            int columns = canvas.columns();
+            int rows = canvas.rows();
+            terminal = new VT320(columns, rows) {
+                public void sendData(byte[] b, int offset, int length) throws IOException {
+                    session.write(b, offset, length);
+                }
+
+                public void beep() {
+                }
+
+                public void resize() {
+                }
+            };
+            keyboard = new Keyboard(terminal);
+            canvas.attach(terminal, keyboard);
+            canvas.setStatus(user + "@" + host);
+
+            session.requestPty("xterm", columns, rows);
+            session.requestShell();
+
+            byte[] buffer = new byte[4096];
+            while (running) {
+                int n = session.read(buffer, 0, buffer.length);
+                if (n < 0) {
+                    break;
+                }
+                // The device's default encoding is ISO8859_1, so the decode is
+                // ours to do. See Utf8.
+                terminal.putString(Utf8.decode(buffer, 0, n));
+                canvas.repaint();
+            }
+            canvas.setStatus("disconnected");
+        } catch (IOException e) {
+            fail(e.getMessage() == null ? e.toString() : e.getMessage());
+        } finally {
+            closeQuietly();
+        }
+    }
+
+    private void fail(final String message) {
+        canvas.setStatus("");
+        show(message, AlertType.ERROR, setup);
+    }
+
+    private void show(String message, AlertType type, Displayable next) {
+        Alert alert = new Alert("berryssh", message, null, type);
+        alert.setTimeout(Alert.FOREVER);
+        display.setCurrent(alert, next);
+    }
+
+    private static int parsePort(String text) {
+        try {
+            int port = Integer.parseInt(text.trim());
+            return port > 0 && port < 65536 ? port : 22;
+        } catch (NumberFormatException e) {
+            return 22;
+        }
+    }
+
+    private void shutdown() {
+        running = false;
+        closeQuietly();
+    }
+
+    private void closeQuietly() {
+        try {
+            if (channel != null) {
+                channel.close();
+            }
+        } catch (IOException e) {
+            // Going anyway.
+        }
+        try {
+            if (socket != null) {
+                socket.close();
+            }
+        } catch (IOException e) {
+            // Going anyway.
+        }
+        channel = null;
+        socket = null;
+    }
+}

--- a/ssh/src/berryssh/device/Keyboard.java
+++ b/ssh/src/berryssh/device/Keyboard.java
@@ -1,0 +1,164 @@
+package berryssh.device;
+
+import javax.microedition.lcdui.Canvas;
+
+import berryssh.terminal.VT320;
+
+/**
+ * Turns MIDP key events into terminal input.
+ *
+ * A terminal needs keys a handset does not have. The BlackBerry QWERTY covers
+ * the letters and, through Alt, the symbols printed on the keycaps — but there
+ * is no Ctrl, no Esc, and no function row, and those are not optional for
+ * anything you would actually want a terminal for.
+ *
+ * Ctrl is therefore sticky rather than held: press the Ctrl command, then the
+ * letter. Holding two keys is awkward on a thumb keyboard and impossible to
+ * detect portably, since MIDP reports key presses and not modifier state.
+ *
+ * <b>What is assumed rather than measured.</b> MIDP guarantees the game actions
+ * and the numeric keypad codes, and those are what the arrows and the trackpad
+ * come through as. It says nothing about what a BlackBerry sends for its own
+ * Escape, Menu, Symbol and Alt keys, and this is written against the plain MIDP
+ * values without those having been read off the hardware. The probe in spike1
+ * reports the code of the last key pressed and is the way to settle them; until
+ * it has been run, the constants below marked as unverified are the plausible
+ * values and not the known ones.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Keyboard {
+
+    private static final int ASCII_BACKSPACE = 8;
+    private static final int ASCII_TAB = 9;
+    private static final int ASCII_LINE_FEED = 10;
+    private static final int ASCII_CARRIAGE_RETURN = 13;
+    private static final int ASCII_ESCAPE = 27;
+    private static final int ASCII_DELETE = 127;
+
+    /**
+     * Unverified: the code a BlackBerry sends for its Escape key. On the
+     * devices this targets it is generally the same negative code used for
+     * "back", but that has not been read off the hardware here.
+     */
+    private static final int BLACKBERRY_ESCAPE = -8;
+
+    private final VT320 terminal;
+
+    private boolean controlPending;
+
+    public Keyboard(VT320 terminal) {
+        this.terminal = terminal;
+    }
+
+    /** True while the next key will be sent as a control character. */
+    public boolean controlPending() {
+        return controlPending;
+    }
+
+    /** Arms or disarms the sticky Ctrl. */
+    public void toggleControl() {
+        controlPending = !controlPending;
+    }
+
+    /** Sends Escape on its own, for the key the keyboard does not have. */
+    public void sendEscape() {
+        terminal.keyTyped(VT320.VK_ESCAPE, (char) ASCII_ESCAPE, 0);
+    }
+
+    /**
+     * Handles a key.
+     *
+     * @param keyCode    the MIDP key code
+     * @param gameAction the canvas's game action for it, or 0
+     */
+    public void keyPressed(int keyCode, int gameAction) {
+        // The game actions come first: on this hardware they are the trackpad,
+        // and MIDP guarantees them where it guarantees nothing about the
+        // physical keys.
+        switch (gameAction) {
+            case Canvas.UP:
+                terminal.keyPressed(VT320.VK_UP, 0);
+                return;
+            case Canvas.DOWN:
+                terminal.keyPressed(VT320.VK_DOWN, 0);
+                return;
+            case Canvas.LEFT:
+                terminal.keyPressed(VT320.VK_LEFT, 0);
+                return;
+            case Canvas.RIGHT:
+                terminal.keyPressed(VT320.VK_RIGHT, 0);
+                return;
+            default:
+                break;
+        }
+
+        if (keyCode == BLACKBERRY_ESCAPE) {
+            sendEscape();
+            return;
+        }
+
+        switch (keyCode) {
+            case ASCII_CARRIAGE_RETURN:
+            case ASCII_LINE_FEED:
+                terminal.keyTyped(VT320.VK_ENTER, (char) 0, 0);
+                return;
+            case ASCII_BACKSPACE:
+            case ASCII_DELETE:
+                terminal.keyTyped(VT320.VK_BACK_SPACE, (char) ASCII_BACKSPACE, 0);
+                return;
+            case ASCII_TAB:
+                terminal.keyTyped(VT320.VK_TAB, (char) ASCII_TAB, 0);
+                return;
+            case ASCII_ESCAPE:
+                sendEscape();
+                return;
+            default:
+                break;
+        }
+
+        if (keyCode <= 0) {
+            // A negative code from a key we have no mapping for. Dropping it is
+            // right: inventing a character would put rubbish into the session.
+            return;
+        }
+
+        char c = (char) keyCode;
+        if (controlPending) {
+            controlPending = false;
+            int control = controlOf(c);
+            if (control >= 0) {
+                terminal.keyTyped(0, (char) control, 0);
+            }
+            return;
+        }
+        terminal.keyTyped(0, c, 0);
+    }
+
+    /**
+     * The control character for a key, or -1 if there is none.
+     *
+     * Done by arithmetic on the ASCII ranges rather than by case folding. The
+     * device's locale is Turkish, where upper-casing 'i' gives a dotted capital
+     * that is not 'I', so Ctrl-I would stop being Tab — silently, and only on
+     * that one letter.
+     */
+    static int controlOf(char c) {
+        if (c >= 'a' && c <= 'z') {
+            return c - 'a' + 1;
+        }
+        if (c >= 'A' && c <= 'Z') {
+            return c - 'A' + 1;
+        }
+        switch (c) {
+            case ' ':  return 0;    // Ctrl-Space, the NUL a few programs want
+            case '[':  return 27;   // Ctrl-[ is Escape
+            case '\\': return 28;
+            case ']':  return 29;
+            case '^':  return 30;
+            case '_':  return 31;
+            case '?':  return 127;  // Ctrl-? is Delete
+            default:   return -1;
+        }
+    }
+}

--- a/ssh/src/berryssh/device/TerminalCanvas.java
+++ b/ssh/src/berryssh/device/TerminalCanvas.java
@@ -1,0 +1,119 @@
+package berryssh.device;
+
+import java.io.IOException;
+
+import javax.microedition.lcdui.Canvas;
+import javax.microedition.lcdui.Graphics;
+
+import berryssh.terminal.BitmapFont;
+import berryssh.terminal.VT320;
+
+/**
+ * The terminal on screen.
+ *
+ * Drawing is per character cell out of the font atlas rather than through
+ * MIDP's text API, for the reason in {@link BitmapFont}: the smallest system
+ * font this device offers gives a 21x13 terminal, which is not one.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class TerminalCanvas extends Canvas {
+
+    private static final int BACKGROUND = 0x000000;
+    private static final int FOREGROUND = 0xffffff;
+    private static final int STATUS = 0x808080;
+
+    private final BitmapFont font;
+    private VT320 terminal;
+    private Keyboard keyboard;
+    private String status = "";
+
+    public TerminalCanvas(BitmapFont font) {
+        this.font = font;
+        setFullScreenMode(true);
+    }
+
+    public void attach(VT320 terminal, Keyboard keyboard) {
+        this.terminal = terminal;
+        this.keyboard = keyboard;
+        repaint();
+    }
+
+    /** How many columns of this font fit the canvas. */
+    public int columns() {
+        return font.columnsIn(getWidth());
+    }
+
+    /** Rows, less one kept for the status line. */
+    public int rows() {
+        return font.rowsIn(getHeight()) - 1;
+    }
+
+    public void setStatus(String message) {
+        status = message == null ? "" : message;
+        repaint();
+    }
+
+    protected void paint(Graphics g) {
+        int width = getWidth();
+        int height = getHeight();
+
+        g.setColor(BACKGROUND);
+        g.fillRect(0, 0, width, height);
+
+        if (terminal != null) {
+            font.setColours(FOREGROUND, BACKGROUND);
+            int columns = columns();
+            int rows = rows();
+            for (int row = 0; row < rows; row++) {
+                for (int column = 0; column < columns; column++) {
+                    char c = terminal.getChar(column, row);
+                    if (c > 32) {
+                        font.drawChar(g, c, column * font.cellWidth(), row * font.cellHeight());
+                    }
+                }
+            }
+        }
+
+        // The status line carries the one piece of state the terminal itself
+        // cannot show: whether the sticky Ctrl is armed. Without it, an armed
+        // Ctrl is invisible until it swallows the next keystroke.
+        String line = status;
+        if (keyboard != null && keyboard.controlPending()) {
+            line = "^ " + line;
+        }
+        font.setColours(STATUS, BACKGROUND);
+        int y = height - font.cellHeight();
+        for (int i = 0; i < line.length() && i < columns(); i++) {
+            font.drawChar(g, line.charAt(i), i * font.cellWidth(), y);
+        }
+    }
+
+    protected void keyPressed(int keyCode) {
+        deliver(keyCode);
+    }
+
+    /**
+     * Key repeat is available on this device and is wanted: holding a cursor
+     * key should scroll rather than move once.
+     */
+    protected void keyRepeated(int keyCode) {
+        deliver(keyCode);
+    }
+
+    private void deliver(int keyCode) {
+        if (keyboard == null) {
+            return;
+        }
+        int action = 0;
+        try {
+            action = getGameAction(keyCode);
+        } catch (IllegalArgumentException e) {
+            // MIDP allows this for a code it does not recognise, and a QWERTY
+            // handset produces plenty it does not. The key is still a key.
+            action = 0;
+        }
+        keyboard.keyPressed(keyCode, action);
+        repaint();
+    }
+}


### PR DESCRIPTION
Add the keyboard mapping and the MIDlet that ties everything together

The application: a setup form, a socket, the handshake, host key trust,
password authentication, a pty, a shell, and the terminal on a canvas. It
builds to a 99 KB jar at class file version 47, preverified, with the font
atlases inside it.

Two checks on that jar are worth more than they look. It carries StackMap
attributes, without which the device rejects the suite as "907 Invalid JAR". And
it contains no reference to net.rim anywhere at all — which is the entire
premise of the project, now demonstrable rather than asserted: code that never
reaches a protected API needs no signature from an authority that no longer
exists.

Networking runs off the event thread. On this platform the first socket open
can block for seconds while the radio comes up, and a blocked event thread is a
frozen screen. Entropy seeding starts at launch rather than at connect, so its
tenth of a second is spent while the user is still typing a hostname.

Ctrl is sticky rather than held: press the command, then the letter. Holding
two keys is awkward on a thumb keyboard and cannot be detected portably anyway,
since MIDP reports presses and not modifier state. The status line shows when
it is armed, because an armed Ctrl is otherwise invisible until it swallows the
next keystroke. Control characters are computed by arithmetic on the ASCII
ranges rather than by case folding — under a Turkish locale, upper-casing 'i'
gives a dotted capital that is not 'I', so Ctrl-I would quietly stop being Tab.

#11 is left open on purpose. The arrows and the trackpad go through MIDP's game
actions, which are guaranteed and correct. What is not settled is what a
BlackBerry sends for its own Escape, Menu, Symbol and Alt keys: MIDP says
nothing about those, and the values here are plausible rather than known. The
probe in spike1 reports the code of the last key pressed and is the way to
settle them — it needs the physical handset, which is the one thing this
session could not reach. The unverified constants are marked as such in
Keyboard.

The MIDlet has never been run on the device for the same reason. Everything
below it has been verified against a real OpenSSH server from the host, and the
whole tree compiles under the CLDC bootclasspath, but "it builds and the
protocol works" is not "it runs on a 9790".

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

