### PR TITLE
Wait for the canvas before asking it how big it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] Host key trust, stored in RMS
 - [x] VT320 terminal emulation, and a bitmap font renderer
 - [x] A MIDlet that connects, authenticates and runs a shell
+- [x] Runs on a Bold 9790: connects, authenticates, opens a shell
 - [ ] Keyboard mapping confirmed against the hardware's real key codes
 
 ## Prior art

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -45,7 +45,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private final Command quit = new Command("Quit", Command.EXIT, 2);
     private final Command control = new Command("Ctrl", Command.SCREEN, 1);
     private final Command escape = new Command("Esc", Command.SCREEN, 2);
-    private final Command disconnect = new Command("Disconnect", Command.STOP, 3);
+    private final Command keys = new Command("Keys", Command.SCREEN, 3);
+    private final Command disconnect = new Command("Disconnect", Command.STOP, 4);
 
     private Display display;
     private Form setup;
@@ -121,6 +122,10 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             keyboard.sendEscape();
             return;
         }
+        if (command == keys) {
+            canvas.toggleKeyCodes();
+            return;
+        }
         if (command == disconnect) {
             shutdown();
             display.setCurrent(setup);
@@ -149,6 +154,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         canvas = new TerminalCanvas(font);
         canvas.addCommand(control);
         canvas.addCommand(escape);
+        canvas.addCommand(keys);
         canvas.addCommand(disconnect);
         canvas.setCommandListener(this);
         canvas.setStatus("connecting to " + host + "...");
@@ -201,6 +207,11 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             final Channel session = Channel.openSession(connection);
             channel = session;
 
+            // The canvas has to be on screen before its size means anything:
+            // setCurrent is asynchronous and full-screen mode only applies once
+            // it is shown. Asking too early returns a zero height, and the
+            // terminal is then told it has no rows.
+            canvas.awaitShown(5000);
             int columns = canvas.columns();
             int rows = canvas.rows();
             terminal = new VT320(columns, rows) {
@@ -216,7 +227,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             };
             keyboard = new Keyboard(terminal);
             canvas.attach(terminal, keyboard);
-            canvas.setStatus(user + "@" + host);
+            canvas.setStatus(user + "@" + host + "  " + columns + "x" + rows);
 
             session.requestPty("xterm", columns, rows);
             session.requestShell();

--- a/ssh/src/berryssh/device/TerminalCanvas.java
+++ b/ssh/src/berryssh/device/TerminalCanvas.java
@@ -28,6 +28,10 @@ public final class TerminalCanvas extends Canvas {
     private Keyboard keyboard;
     private String status = "";
 
+    private boolean shown;
+    private boolean showKeyCodes;
+    private String lastKey = "";
+
     public TerminalCanvas(BitmapFont font) {
         this.font = font;
         setFullScreenMode(true);
@@ -39,14 +43,75 @@ public final class TerminalCanvas extends Canvas {
         repaint();
     }
 
-    /** How many columns of this font fit the canvas. */
+    /**
+     * Blocks until the canvas is actually on screen.
+     *
+     * setCurrent is asynchronous and full-screen mode is not applied until the
+     * canvas is shown, so getWidth and getHeight are not to be trusted before
+     * this returns. Reading them early gave a zero height, hence a negative row
+     * count, hence a paint loop that never ran — a blank terminal under a
+     * status line that drew perfectly well.
+     */
+    public synchronized void awaitShown(long milliseconds) {
+        long deadline = System.currentTimeMillis() + milliseconds;
+        while (!shown) {
+            long left = deadline - System.currentTimeMillis();
+            if (left <= 0) {
+                return;
+            }
+            try {
+                wait(left);
+            } catch (InterruptedException e) {
+                return;
+            }
+        }
+    }
+
+    protected synchronized void showNotify() {
+        shown = true;
+        notifyAll();
+    }
+
+    protected void sizeChanged(int width, int height) {
+        synchronized (this) {
+            shown = true;
+            notifyAll();
+        }
+        repaint();
+    }
+
+    /**
+     * How many columns of this font fit the canvas.
+     *
+     * Never below one. A zero or negative grid is not a smaller terminal, it is
+     * a terminal that draws nothing, and it should not be reachable by
+     * arithmetic on a size that has not arrived yet.
+     */
     public int columns() {
-        return font.columnsIn(getWidth());
+        return atLeastOne(font.columnsIn(getWidth()));
     }
 
     /** Rows, less one kept for the status line. */
     public int rows() {
-        return font.rowsIn(getHeight()) - 1;
+        return atLeastOne(font.rowsIn(getHeight()) - 1);
+    }
+
+    private static int atLeastOne(int n) {
+        return n < 1 ? 1 : n;
+    }
+
+    /**
+     * Shows the raw code of each key pressed instead of the status message.
+     *
+     * This is the measurement issue #11 has been waiting for. MIDP guarantees
+     * nothing about what a BlackBerry sends for its own Escape, Menu, Symbol
+     * and Alt keys, and putting the readout in the app itself means the numbers
+     * can be read off the hardware in the place they matter rather than from a
+     * separate probe.
+     */
+    public void toggleKeyCodes() {
+        showKeyCodes = !showKeyCodes;
+        repaint();
     }
 
     public void setStatus(String message) {
@@ -78,7 +143,7 @@ public final class TerminalCanvas extends Canvas {
         // The status line carries the one piece of state the terminal itself
         // cannot show: whether the sticky Ctrl is armed. Without it, an armed
         // Ctrl is invisible until it swallows the next keystroke.
-        String line = status;
+        String line = showKeyCodes ? lastKey : status;
         if (keyboard != null && keyboard.controlPending()) {
             line = "^ " + line;
         }
@@ -102,9 +167,6 @@ public final class TerminalCanvas extends Canvas {
     }
 
     private void deliver(int keyCode) {
-        if (keyboard == null) {
-            return;
-        }
         int action = 0;
         try {
             action = getGameAction(keyCode);
@@ -113,7 +175,16 @@ public final class TerminalCanvas extends Canvas {
             // handset produces plenty it does not. The key is still a key.
             action = 0;
         }
-        keyboard.keyPressed(keyCode, action);
+
+        // Recorded before anything can go wrong with it, and whether or not
+        // there is a session yet: a key that produces no output is exactly the
+        // case this readout exists to explain.
+        lastKey = "key " + keyCode + " action " + action
+            + " grid " + columns() + "x" + rows();
+
+        if (keyboard != null) {
+            keyboard.keyPressed(keyCode, action);
+        }
         repaint();
     }
 }


### PR DESCRIPTION
Wait for the canvas before asking it how big it is

First run on the 9790 connected, authenticated and opened a shell, and then
showed a blank terminal under a perfectly good status line.

The two are drawn by the same code, so the renderer was never the problem. The
grid was. setCurrent is asynchronous and full-screen mode is not applied until
the canvas is shown, so the network thread was reading getWidth and getHeight
from a canvas that had not been laid out. A zero height gives rows() = -1, the
paint loop never runs, and the status line — drawn outside that loop — carries
on as if everything were fine. The terminal was also told it had -1 rows, so
what the server sent had nowhere to go.

Two changes, because either alone would leave the failure silent. The session
now waits for the canvas to be shown before measuring it. And columns() and
rows() will not return less than one: a zero grid is not a small terminal, it
is a terminal that draws nothing, and it should not be reachable by arithmetic
on a size that has not arrived yet.

The negotiated grid is shown in the status line, so a wrong one is visible
rather than silent.

Also adds a Keys command, which switches the status line to the raw code and
game action of each key pressed. That is the measurement #11 has been waiting
for: MIDP guarantees nothing about what a BlackBerry sends for its own Escape,
Menu, Symbol and Alt keys, and reading the numbers off the hardware inside the
application is better than a separate probe, because it is the same key
handling path that will use them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

