### PR TITLE
Make it possible to leave the terminal

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")"
 
 NAME=berryssh
 VENDOR="berryssh"
-VERSION=0.1.1
+VERSION=0.1.2
 MIDLET_CLASS=berryssh.device.BerrysshMIDlet
 
 OUT=out

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -46,7 +46,9 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private final Command control = new Command("Ctrl", Command.SCREEN, 1);
     private final Command escape = new Command("Esc", Command.SCREEN, 2);
     private final Command keys = new Command("Keys", Command.SCREEN, 3);
-    private final Command disconnect = new Command("Disconnect", Command.STOP, 4);
+    private final Command fullScreen = new Command("Full screen", Command.SCREEN, 4);
+    private final Command reconnect = new Command("Reconnect", Command.SCREEN, 5);
+    private final Command disconnect = new Command("Disconnect", Command.STOP, 6);
 
     private Display display;
     private Form setup;
@@ -65,6 +67,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private SocketConnection socket;
     private Channel channel;
     private volatile boolean running;
+    private boolean fullScreenOn;
 
     protected void startApp() {
         if (display != null) {
@@ -113,17 +116,34 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             startSession();
             return;
         }
+        // The keyboard only exists once a session has attached one, and these
+        // commands are in the menu from the moment the screen appears.
         if (command == control) {
-            keyboard.toggleControl();
-            canvas.repaint();
+            if (keyboard != null) {
+                keyboard.toggleControl();
+                canvas.repaint();
+            }
             return;
         }
         if (command == escape) {
-            keyboard.sendEscape();
+            if (keyboard != null) {
+                keyboard.sendEscape();
+            }
             return;
         }
         if (command == keys) {
             canvas.toggleKeyCodes();
+            return;
+        }
+        if (command == fullScreen) {
+            fullScreenOn = !fullScreenOn;
+            canvas.setFullScreen(fullScreenOn);
+            resizeTerminal();
+            return;
+        }
+        if (command == reconnect) {
+            shutdown();
+            startSession();
             return;
         }
         if (command == disconnect) {
@@ -155,7 +175,13 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         canvas.addCommand(control);
         canvas.addCommand(escape);
         canvas.addCommand(keys);
+        canvas.addCommand(fullScreen);
+        canvas.addCommand(reconnect);
         canvas.addCommand(disconnect);
+        // Quit belongs on this screen too. Reaching it only from the setup
+        // form means a session that will not disconnect cleanly is a session
+        // you cannot leave.
+        canvas.addCommand(quit);
         canvas.setCommandListener(this);
         canvas.setStatus("connecting to " + host + "...");
         display.setCurrent(canvas);
@@ -289,7 +315,17 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             + " (last error: " + (last == null ? "none" : last.getMessage()) + ")");
     }
 
+    /**
+     * Reports a fault, unless we caused it.
+     *
+     * Disconnecting closes the socket under a reader that is blocked on it, so
+     * the read fails by design. Showing that as an error would put a warning in
+     * front of a user who just chose to leave.
+     */
     private void fail(final String message) {
+        if (!running) {
+            return;
+        }
         canvas.setStatus("");
         show(message, AlertType.ERROR, setup);
     }
@@ -298,6 +334,29 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         Alert alert = new Alert("berryssh", message, null, type);
         alert.setTimeout(Alert.FOREVER);
         display.setCurrent(alert, next);
+    }
+
+    /**
+     * Re-agrees the terminal size after the screen changes shape.
+     *
+     * Both halves are needed: the emulator has to rewrap its buffer, and the
+     * server has to be told, or a full-screen program keeps drawing to the old
+     * dimensions and the display tears.
+     */
+    private void resizeTerminal() {
+        if (terminal == null || channel == null) {
+            return;
+        }
+        int columns = canvas.columns();
+        int rows = canvas.rows();
+        terminal.setScreenSize(columns, rows, true);
+        try {
+            channel.windowChange(columns, rows);
+        } catch (IOException e) {
+            // The session is already in trouble if this fails; the read loop
+            // will surface it with a better message than this could.
+        }
+        canvas.setStatus(columns + "x" + rows);
     }
 
     private static int parsePort(String text) {

--- a/ssh/src/berryssh/device/TerminalCanvas.java
+++ b/ssh/src/berryssh/device/TerminalCanvas.java
@@ -32,9 +32,24 @@ public final class TerminalCanvas extends Canvas {
     private boolean showKeyCodes;
     private String lastKey = "";
 
+    /**
+     * Starts windowed rather than full screen, deliberately.
+     *
+     * Full screen buys about two more rows and costs the menu: MIDP does not
+     * promise that commands stay reachable without one, and on this device they
+     * do not. That trade is only ever worth making by choice — a terminal you
+     * cannot get out of is worse than a slightly shorter one, and there is no
+     * other way off this screen, since every command lives in that menu.
+     */
     public TerminalCanvas(BitmapFont font) {
         this.font = font;
-        setFullScreenMode(true);
+        setFullScreenMode(false);
+    }
+
+    /** The size changes, so the caller has to tell the session to resize too. */
+    public void setFullScreen(boolean on) {
+        setFullScreenMode(on);
+        repaint();
     }
 
     public void attach(VT320 terminal, Keyboard keyboard) {


### PR DESCRIPTION
Make it possible to leave the terminal

Reported from the device: once connected there was no way out of the session,
not even to quit the application.

The cause was full-screen mode. It buys about two rows and costs the menu —
MIDP does not promise commands stay reachable without one, and on this device
they are not. Every command the terminal has lived in that menu, so turning it
on took Ctrl, Esc, Keys and Disconnect with it. The canvas now starts windowed,
and full screen is a command you can choose and un-choose, which is the only
form that trade should ever take: a terminal you cannot get out of is worse
than a slightly shorter one.

Quit is on the terminal screen as well now. Reaching it only from the setup
form meant a session that would not disconnect cleanly was a session you could
not leave — which is the same bug wearing a different hat.

Reconnect is added, since dropping back to the form and retyping a password to
recover from a dead link is not a recovery.

Two fixes underneath. A deliberate disconnect closes the socket under a reader
blocked on it, so the read fails by design; that was being shown as an error to
someone who had just chosen to leave, and now is not. And changing the screen
shape now tells both the emulator and the server, or a full-screen program
keeps drawing to the old dimensions and the display tears.

The Ctrl and Esc commands are in the menu from the moment the screen appears,
which is before a session has attached a keyboard to them. They no longer
assume otherwise.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

