### PR TITLE
Treat a character as a character, and make backspace work

### DIFF
--- a/spike2/src/TerminalTests.java
+++ b/spike2/src/TerminalTests.java
@@ -1,3 +1,4 @@
+import berryssh.device.Keyboard;
 import berryssh.terminal.VT320;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ public class TerminalTests {
         handlesEscapeSequences();
         scrolls();
         sendsKeys();
+        dispatchesKeys();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -124,6 +126,77 @@ public class TerminalTests {
         arrows.keyPressed(VT320.VK_UP, 0);
         checkTrue("the up arrow sends an escape sequence",
             arrows.sent.length() >= 3 && arrows.sent.charAt(0) == 27);
+    }
+
+    /**
+     * Key dispatch, and specifically the ordering that got it wrong on the
+     * device.
+     *
+     * MIDP lets a device map keys to game actions, and BlackBerry maps the
+     * letters so that games written for a numeric keypad work on a QWERTY: 'w'
+     * reports UP, 'a' reports LEFT. Consulting the game action before the
+     * character therefore turns typing into cursor movement on exactly those
+     * letters and leaves every other key working — which is why it presented as
+     * "some keys do nothing and some produce something else" rather than as a
+     * keyboard that was plainly broken.
+     *
+     * The MIDP game action values are written out here rather than imported, so
+     * the test does not depend on the stub jar being on the host classpath.
+     */
+    private static void dispatchesKeys() {
+        final int UP = 1, LEFT = 2, RIGHT = 5, DOWN = 6;
+
+        // A letter that the device also calls a direction is still a letter.
+        checkTrue("'w' types 'w' even though the device reports UP",
+            "w".equals(sendKey('w', UP)));
+        checkTrue("'a' types 'a' even though the device reports LEFT",
+            "a".equals(sendKey('a', LEFT)));
+        checkTrue("'s' types 's' even though the device reports DOWN",
+            "s".equals(sendKey('s', DOWN)));
+        checkTrue("'d' types 'd' even though the device reports RIGHT",
+            "d".equals(sendKey('d', RIGHT)));
+
+        checkTrue("a letter with no game action still types itself",
+            "q".equals(sendKey('q', 0)));
+        checkTrue("space is a character, not a fire button",
+            " ".equals(sendKey(' ', 8)));
+
+        // The trackpad reports a direction and no character, so it still moves.
+        String up = sendKey(-1, UP);
+        checkTrue("a key with no character and a direction sends a cursor sequence",
+            up.length() >= 3 && up.charAt(0) == 27);
+
+        checkTrue("Enter sends a carriage return", sendKey(13, 0).indexOf('\r') >= 0);
+        // Backspace has to reach VT320 through keyPressed: keyTyped drops it,
+        // which sent nothing at all and left no way to correct a typo.
+        checkTrue("Backspace sends something", sendKey(8, 0).length() > 0);
+        checkTrue("Delete deletes too, on a handset with one such key",
+            sendKey(127, 0).equals(sendKey(8, 0)) && sendKey(127, 0).length() > 0);
+        checkTrue("Tab sends one", "\t".equals(sendKey(9, 0)));
+
+        // A key we know nothing about must send nothing rather than a guess.
+        checkTrue("an unmapped key sends nothing", "".equals(sendKey(-999, 0)));
+
+        // Sticky Ctrl, on the character path.
+        Headless t = new Headless(20, 5);
+        Keyboard k = new Keyboard(t);
+        k.toggleControl();
+        checkTrue("Ctrl is armed", k.controlPending());
+        k.keyPressed('c', 0);
+        checkTrue("Ctrl-C sends 0x03 and disarms",
+            t.sent.length() == 1 && t.sent.charAt(0) == 3 && !k.controlPending());
+
+        // Ctrl-I must be Tab. Under a Turkish locale a case fold would make
+        // this the one letter of the alphabet that stopped working.
+        checkTrue("Ctrl-I is Tab under any locale", Keyboard.controlOf('i') == 9);
+        checkTrue("Ctrl-I is Tab from the capital too", Keyboard.controlOf('I') == 9);
+    }
+
+    /** Feeds one key through the dispatcher and returns what reached the wire. */
+    private static String sendKey(int keyCode, int gameAction) {
+        Headless t = new Headless(20, 5);
+        new Keyboard(t).keyPressed(keyCode, gameAction);
+        return t.sent.toString();
     }
 
     /** Builds an escape sequence without putting a control byte in the source. */

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -85,9 +85,14 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         }).start();
 
         setup = new Form("berryssh");
-        hostField = new TextField("Host", "", 64, TextField.URL);
+        // URL and EMAILADDR both put the device into an input mode that does
+        // not capitalise the first letter. TextField.ANY does, which made
+        // every username start with a capital and need correcting by hand.
+        hostField = new TextField("Host", "", 64,
+            TextField.URL | TextField.NON_PREDICTIVE);
         portField = new TextField("Port", "22", 5, TextField.NUMERIC);
-        userField = new TextField("User", "", 32, TextField.ANY);
+        userField = new TextField("User", "", 32,
+            TextField.EMAILADDR | TextField.NON_PREDICTIVE);
         passwordField = new TextField("Password", "", 64, TextField.PASSWORD);
         setup.append(hostField);
         setup.append(portField);

--- a/ssh/src/berryssh/device/Keyboard.java
+++ b/ssh/src/berryssh/device/Keyboard.java
@@ -73,9 +73,59 @@ public final class Keyboard {
      * @param gameAction the canvas's game action for it, or 0
      */
     public void keyPressed(int keyCode, int gameAction) {
-        // The game actions come first: on this hardware they are the trackpad,
-        // and MIDP guarantees them where it guarantees nothing about the
-        // physical keys.
+        // A character is a character, whatever else the device calls it.
+        //
+        // This ordering is the whole point. MIDP lets a device map keys to game
+        // actions, and BlackBerry maps the letters — 'w' is UP, 'a' is LEFT,
+        // 's' is DOWN, 'd' is RIGHT — so that games written for a numeric
+        // keypad work on a QWERTY. Asking for the game action first therefore
+        // turns typing into cursor movement on exactly those letters, and
+        // leaves the rest working, which is what makes it look like a font or
+        // an encoding problem rather than a dispatch one.
+        //
+        // The trackpad and any dedicated cursor keys report no character, so
+        // they still reach the game actions below.
+        if (keyCode > 0 && isPrintable((char) keyCode)) {
+            type((char) keyCode);
+            return;
+        }
+
+        if (keyCode == BLACKBERRY_ESCAPE) {
+            sendEscape();
+            return;
+        }
+
+        switch (keyCode) {
+            case ASCII_CARRIAGE_RETURN:
+            case ASCII_LINE_FEED:
+                terminal.keyTyped(VT320.VK_ENTER, (char) 0, 0);
+                return;
+            case ASCII_BACKSPACE:
+                // Through keyPressed, not keyTyped. VT320 splits its input that
+                // way — its own dispatchKey routes backspace to keyPressed —
+                // and keyTyped drops it silently, so this sent nothing at all
+                // and there was no way to correct a typo.
+                terminal.keyPressed(VT320.VK_BACK_SPACE, 0);
+                return;
+            case ASCII_DELETE:
+                // Also backspace. VT320 has no keyPressed handling for DEL, and
+                // this handset has one deletion key rather than two — sending
+                // nothing because the codes differ in ASCII would be pedantry
+                // at the cost of the key working.
+                terminal.keyPressed(VT320.VK_BACK_SPACE, 0);
+                return;
+            case ASCII_TAB:
+                terminal.keyTyped(VT320.VK_TAB, (char) ASCII_TAB, 0);
+                return;
+            case ASCII_ESCAPE:
+                sendEscape();
+                return;
+            default:
+                break;
+        }
+
+        // Only now the game actions, which on this hardware means the trackpad
+        // and anything else with no character of its own.
         switch (gameAction) {
             case Canvas.UP:
                 terminal.keyPressed(VT320.VK_UP, 0);
@@ -93,37 +143,12 @@ public final class Keyboard {
                 break;
         }
 
-        if (keyCode == BLACKBERRY_ESCAPE) {
-            sendEscape();
-            return;
-        }
+        // A key we have no mapping for. Dropping it is right: inventing a
+        // character would put rubbish into the session, and the Keys readout is
+        // there to find out what it was.
+    }
 
-        switch (keyCode) {
-            case ASCII_CARRIAGE_RETURN:
-            case ASCII_LINE_FEED:
-                terminal.keyTyped(VT320.VK_ENTER, (char) 0, 0);
-                return;
-            case ASCII_BACKSPACE:
-            case ASCII_DELETE:
-                terminal.keyTyped(VT320.VK_BACK_SPACE, (char) ASCII_BACKSPACE, 0);
-                return;
-            case ASCII_TAB:
-                terminal.keyTyped(VT320.VK_TAB, (char) ASCII_TAB, 0);
-                return;
-            case ASCII_ESCAPE:
-                sendEscape();
-                return;
-            default:
-                break;
-        }
-
-        if (keyCode <= 0) {
-            // A negative code from a key we have no mapping for. Dropping it is
-            // right: inventing a character would put rubbish into the session.
-            return;
-        }
-
-        char c = (char) keyCode;
+    private void type(char c) {
         if (controlPending) {
             controlPending = false;
             int control = controlOf(c);
@@ -136,6 +161,17 @@ public final class Keyboard {
     }
 
     /**
+     * Whether this character is one a terminal should send as itself.
+     *
+     * The C1 range is excluded along with the C0 controls: those arrive as
+     * named keys handled above, and passing one through as a character would
+     * send a byte the far end reads as the start of an escape sequence.
+     */
+    public static boolean isPrintable(char c) {
+        return (c >= 32 && c < 127) || c > 159;
+    }
+
+    /**
      * The control character for a key, or -1 if there is none.
      *
      * Done by arithmetic on the ASCII ranges rather than by case folding. The
@@ -143,7 +179,7 @@ public final class Keyboard {
      * that is not 'I', so Ctrl-I would stop being Tab — silently, and only on
      * that one letter.
      */
-    static int controlOf(char c) {
+    public static int controlOf(char c) {
         if (c >= 'a' && c <= 'z') {
             return c - 'a' + 1;
         }


### PR DESCRIPTION
Treat a character as a character, and make backspace work

Reported from the device: some keys did nothing, and some produced something
other than what was pressed. Two separate faults, both in dispatch.

The first is an ordering mistake. MIDP lets a device map keys to game actions,
and BlackBerry maps the letters — 'w' reports UP, 'a' reports LEFT, 's' DOWN,
'd' RIGHT — so that games written for a numeric keypad work on a QWERTY.
Consulting the game action before the character therefore turned typing into
cursor movement on exactly those letters and left every other key working,
which is why it looked like an encoding or font problem rather than a dispatch
one. Characters are now decided first; game actions are consulted only for keys
that report no character, which on this hardware means the trackpad.

The second is worse in daily use: backspace sent nothing at all, so a typo
could not be corrected. VT320 splits its input in two and its own dispatchKey
routes backspace to keyPressed; keyTyped, which is what this was calling,
discards it silently. Delete is mapped to the same thing — the handset has one
deletion key, and sending nothing because the ASCII codes differ would be
pedantry at the cost of the key working.

Both are now covered by host tests that feed keys through the dispatcher and
check what reaches the wire, including the 'w'-is-UP case that caused this.

Also stops the username field capitalising its first letter. TextField.ANY puts
the device into a mode that does, so every username had to be corrected by hand
on a keyboard where that is several presses. URL and EMAILADDR do not, and are
what the two identifier fields use now.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

