### PR TITLE
Make the transport safe for the two threads that use it

### DIFF
--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -56,6 +56,7 @@ public class ServerTests {
         authenticatesWithRealServer();
         runsAShellOnRealServer();
         rendersARealSessionThroughTheTerminal();
+        survivesTypingWhileOutputArrives();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -395,6 +396,126 @@ public class ServerTests {
             }
             checkTrue("the screen the server cleared is clear", topRowClear);
 
+            channel.close();
+        } finally {
+            socket.close();
+        }
+    }
+
+    /**
+     * Two threads on one connection, which is what the application does every
+     * time somebody types while something is printing.
+     *
+     * The reader sends window updates as it consumes; the writer sends the
+     * keystrokes. Both go through the same transport and the same sequence
+     * numbers, and those numbers are the AEAD nonces — so if sending is not
+     * serialised, two packets get sealed under one nonce and the far end stops
+     * being able to decrypt anything. The failure is total and permanent, not
+     * intermittent, which is the one mercy in it.
+     *
+     * A marker command afterwards is the check: if the streams desynchronised
+     * at any point, nothing gets that far.
+     */
+    private static void survivesTypingWhileOutputArrives() throws Exception {
+        Socket socket = new Socket(host, port);
+        try {
+            socket.setSoTimeout(30000);
+            EntropyPool random = new EntropyPool();
+            random.seed();
+            Connection connection = new Connection(
+                socket.getInputStream(), socket.getOutputStream(), random);
+            connection.handshake();
+
+            UserAuth auth = new UserAuth(connection, user);
+            auth.begin();
+            auth.queryMethods();
+            auth.password(password);
+
+            final Channel channel = Channel.openSession(connection);
+            channel.requestPty("xterm", 60, 25);
+            channel.requestShell();
+
+            // Big enough to cross the window refill threshold, which is the
+            // whole point: below it the reader never sends anything, only one
+            // thread is writing, and the race this exists to catch cannot
+            // happen. At 1 MB per refill this is several.
+            // Written split so the pty's echo of the command line cannot itself
+            // contain the marker. It can, and did: the loop then ended on the
+            // echo after thirteen bytes and the test measured nothing at all,
+            // which is why it passed with the bug still in place.
+            channel.write(Utf8.encode("seq 1 30''0000\n"));
+
+            final Exception[] writerFailure = new Exception[1];
+            final boolean[] readingDone = new boolean[1];
+            final long[] typed = new long[1];
+            Thread typist = new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        // For as long as the reader is reading, rather than a
+                        // fixed count that finishes in the first moment. The
+                        // contention is the test; a burst that is over before
+                        // the transfer starts exercises nothing.
+                        while (!readingDone[0]) {
+                            channel.write(Utf8.encode("x"));
+                            typed[0]++;
+                        }
+                    } catch (Exception e) {
+                        writerFailure[0] = e;
+                    }
+                }
+            });
+            typist.start();
+
+            // Only the tail is kept: several megabytes in a StringBuffer would
+            // be measuring the host's memory, not the protocol.
+            boolean sawEnd = false;
+            long total = 0;
+            StringBuffer tail = new StringBuffer();
+            byte[] buffer = new byte[4096];
+            while (!sawEnd) {
+                int n = channel.read(buffer, 0, buffer.length);
+                if (n < 0) {
+                    System.out.println("        read ended after " + total
+                        + " bytes; finished=" + channel.isFinished());
+                    break;
+                }
+                total += n;
+                tail.append(Utf8.decode(buffer, 0, n));
+                if (tail.length() > 4096) {
+                    tail.delete(0, tail.length() - 2048);
+                }
+                if (tail.toString().indexOf("300000") >= 0) {
+                    sawEnd = true;
+                }
+            }
+            readingDone[0] = true;
+            typist.join(30000);
+
+            checkTrue("typing while output arrives does not break the writer",
+                writerFailure[0] == null);
+            checkTrue("all of the output arrived, past several window refills",
+                sawEnd && total > 1024 * 1024);
+            System.out.println("        " + (total / 1024) + " KB read while "
+                + typed[0] + " keystrokes were sent");
+
+            // Ctrl-U first, to throw away the line of 'x' the typing left.
+            channel.write(new byte[] { 0x15 });
+            channel.write(Utf8.encode("echo st''ill-alive\n"));
+
+            StringBuffer after = new StringBuffer();
+            long deadline = System.currentTimeMillis() + 15000;
+            while (after.toString().indexOf("still-alive") < 0
+                    && System.currentTimeMillis() < deadline) {
+                int n = channel.read(buffer, 0, buffer.length);
+                if (n < 0) {
+                    break;
+                }
+                after.append(Utf8.decode(buffer, 0, n));
+            }
+            checkTrue("the connection still works afterwards",
+                after.toString().indexOf("still-alive") >= 0);
+
+            channel.write(Utf8.encode("exit\n"));
             channel.close();
         } finally {
             socket.close();

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -271,7 +271,13 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
                 }
                 // The device's default encoding is ISO8859_1, so the decode is
                 // ours to do. See Utf8.
-                terminal.putString(Utf8.decode(buffer, 0, n));
+                // The painter reads this buffer from the event thread while
+                // this thread writes it. VT320 publishes a mutex for exactly
+                // that, and using it is the difference between a redraw during
+                // a scroll and an index off the end of an array being resized.
+                synchronized (terminal.getTermBufferMutex()) {
+                    terminal.putString(Utf8.decode(buffer, 0, n));
+                }
                 canvas.repaint();
             }
             canvas.setStatus("disconnected");

--- a/ssh/src/berryssh/device/TerminalCanvas.java
+++ b/ssh/src/berryssh/device/TerminalCanvas.java
@@ -145,11 +145,18 @@ public final class TerminalCanvas extends Canvas {
             font.setColours(FOREGROUND, BACKGROUND);
             int columns = columns();
             int rows = rows();
-            for (int row = 0; row < rows; row++) {
-                for (int column = 0; column < columns; column++) {
-                    char c = terminal.getChar(column, row);
-                    if (c > 32) {
-                        font.drawChar(g, c, column * font.cellWidth(), row * font.cellHeight());
+            // Held across the whole screen rather than per character: the
+            // session thread must not scroll the buffer out from under a
+            // half-drawn frame, which would tear the picture and, during a
+            // resize, index past the end of it.
+            synchronized (terminal.getTermBufferMutex()) {
+                for (int row = 0; row < rows; row++) {
+                    for (int column = 0; column < columns; column++) {
+                        char c = terminal.getChar(column, row);
+                        if (c > 32) {
+                            font.drawChar(g, c,
+                                column * font.cellWidth(), row * font.cellHeight());
+                        }
                     }
                 }
             }

--- a/ssh/src/berryssh/protocol/Channel.java
+++ b/ssh/src/berryssh/protocol/Channel.java
@@ -37,6 +37,15 @@ public final class Channel {
 
     private final Connection connection;
 
+    /**
+     * Guards the server's window, and is what a blocked writer waits on.
+     *
+     * The window is decremented by whoever is sending — the UI thread — and
+     * replenished by whoever is reading, so it is the one piece of channel
+     * state two threads genuinely share.
+     */
+    private final Object windowLock = new Object();
+
     private int remoteId;
     private long remoteWindow;
     private int remoteMaxPacket;
@@ -45,8 +54,8 @@ public final class Channel {
     private byte[] pending = new byte[0];
     private int pendingAt;
 
-    private boolean eof;
-    private boolean closed;
+    private volatile boolean eof;
+    private volatile boolean closed;
     private int exitStatus = -1;
 
     private Channel(Connection connection) {
@@ -144,25 +153,42 @@ public final class Channel {
      */
     public void write(byte[] data, int offset, int length) throws IOException {
         while (length > 0) {
-            while (remoteWindow == 0) {
-                // Nothing to do but read: only the server can reopen its window.
-                pump();
-            }
-            int take = length;
-            if (take > remoteMaxPacket) {
-                take = remoteMaxPacket;
-            }
-            if (take > remoteWindow) {
-                take = (int) remoteWindow;
+            int take;
+            synchronized (windowLock) {
+                // Wait to be told the window opened; do not go and read for it.
+                // Reading here would put a second thread on the socket while
+                // the reader is already parked on it, and both would advance
+                // the receive sequence — so the nonces would diverge and
+                // nothing would decrypt from that point on.
+                while (remoteWindow == 0 && !closed) {
+                    try {
+                        windowLock.wait();
+                    } catch (InterruptedException e) {
+                        throw new SshException("interrupted waiting for the channel window");
+                    }
+                }
+                if (closed) {
+                    throw new SshException("the channel closed before the data could be sent");
+                }
+                take = length;
+                if (take > remoteMaxPacket) {
+                    take = remoteMaxPacket;
+                }
+                if (take > remoteWindow) {
+                    take = (int) remoteWindow;
+                }
+                remoteWindow -= take;
             }
 
+            // Sent outside the lock: writePacket serialises itself, and holding
+            // this one across a socket write would stall the reader's window
+            // updates behind it.
             WireWriter w = new WireWriter(take + 16);
             w.writeByte(Message.CHANNEL_DATA);
             w.writeUint32(remoteId);
             w.writeString(data, offset, take);
             connection.transport().writePacket(w.toByteArray());
 
-            remoteWindow -= take;
             offset += take;
             length -= take;
         }
@@ -225,14 +251,17 @@ public final class Channel {
     }
 
     public void close() throws IOException {
-        if (closed) {
-            return;
+        synchronized (windowLock) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            windowLock.notifyAll();
         }
         WireWriter w = new WireWriter(16);
         w.writeByte(Message.CHANNEL_CLOSE);
         w.writeUint32(remoteId);
         connection.transport().writePacket(w.toByteArray());
-        closed = true;
     }
 
     /** Reads and dispatches exactly one message. */
@@ -267,7 +296,11 @@ public final class Channel {
 
         if (type == Message.CHANNEL_WINDOW_ADJUST) {
             checkRecipient(r.readUint32());
-            remoteWindow += r.readUint32();
+            long more = r.readUint32();
+            synchronized (windowLock) {
+                remoteWindow += more;
+                windowLock.notifyAll();
+            }
             return;
         }
         if (type == Message.CHANNEL_EOF) {
@@ -275,7 +308,12 @@ public final class Channel {
             return;
         }
         if (type == Message.CHANNEL_CLOSE) {
-            closed = true;
+            // Waking any blocked writer matters as much as the flag: without
+            // it, a send that was waiting on the window waits for ever.
+            synchronized (windowLock) {
+                closed = true;
+                windowLock.notifyAll();
+            }
             return;
         }
         if (type == Message.CHANNEL_REQUEST) {

--- a/ssh/src/berryssh/protocol/Transport.java
+++ b/ssh/src/berryssh/protocol/Transport.java
@@ -48,6 +48,20 @@ public final class Transport {
     private final OutputStream out;
 
     /**
+     * One lock per direction, not one lock.
+     *
+     * Sending and receiving each have to be serialised — the sequence numbers
+     * are the AEAD nonces, so a lost increment means two packets sealed under
+     * one nonce, which in a stream cipher is the failure the construction
+     * exists to prevent. But they must be serialised separately: a reader
+     * parked on a socket read holds its lock for as long as the server stays
+     * quiet, and sharing one lock would mean nothing could ever be sent during
+     * that time, which is all of an idle session.
+     */
+    private final Object sendLock = new Object();
+    private final Object receiveLock = new Object();
+
+    /**
      * Padding only has to be unpredictable enough to satisfy RFC 4253's SHOULD.
      * It is not key material: before the key exchange it travels in the clear
      * with nothing to hide, and afterwards the AEAD covers it. Generating a
@@ -150,6 +164,12 @@ public final class Transport {
      * with at least 4 bytes of padding and at least 16 bytes in total.
      */
     public void writePacket(byte[] payload) throws IOException {
+        synchronized (sendLock) {
+            writeLocked(payload);
+        }
+    }
+
+    private void writeLocked(byte[] payload) throws IOException {
         byte[] body = pad(payload);
         if (outgoing == null) {
             byte[] packet = new byte[4 + body.length];
@@ -200,6 +220,12 @@ public final class Transport {
 
     /** Reads one packet and returns its payload. */
     public byte[] readPacket() throws IOException {
+        synchronized (receiveLock) {
+            return readLocked();
+        }
+    }
+
+    private byte[] readLocked() throws IOException {
         byte[] header = new byte[LENGTH_FIELD];
         readFully(header, 0, LENGTH_FIELD);
 


### PR DESCRIPTION
Make the transport safe for the two threads that use it

The application has always had two threads on one connection — a reader
draining the session and the event thread sending keystrokes — and the
transport was written as if it had one.

**What was wrong**

Both threads reach `Transport.writePacket`, which had no synchronization. The
reader gets there through `Channel.read`, which sends `CHANNEL_WINDOW_ADJUST`
as it consumes; the event thread through `VT320.sendData` on every keypress.
Their bytes interleave on one `OutputStream`, and both increment
`sendSequence` unguarded. That counter is the AEAD nonce, so a lost increment
means two packets sealed under one nonce with one key — the failure a stream
cipher construction exists to prevent, not a glitch.

`Channel.write` made it worse: when the server's window was exhausted it called
`pump()`, which reads the socket. So the event thread would start reading while
the reader thread was already parked on a read — two readers, both advancing
`receiveSequence`, each decrypting with a nonce the other had moved.

**What changed**

One lock per direction rather than one lock. Sending and receiving each have to
be serialised, but separately: a reader parked on a socket read holds its lock
for as long as the server stays quiet, and a shared lock would mean nothing
could be sent during that time — which is all of an idle session.

`Channel.write` now waits on a monitor for the window to open and never reads.
The reader replenishes the window and wakes it. Close wakes it too, or a send
blocked on a window would wait for a server that has already gone.

The screen buffer is now held under `VT320.getTermBufferMutex()` while it is
written by the session and read by the painter. That is what the mutex is
published for, and it was not being used.

**How this is verified**

A test that types continuously while several megabytes stream back, crossing
the window refill threshold repeatedly so both threads are genuinely sending.
With the fix: 2.2 MB read while roughly a hundred thousand keystrokes go the
other way. Without the send lock: `connection closed mid-packet` — the server
receives a corrupt packet and hangs up.

Two earlier versions of that test were wrong and both passed against the bug,
which is worth recording because it is the more instructive part. The first
sent too little output to ever cross the refill threshold, so the reader never
sent anything and only one thread was writing. The second used the line count
as its end marker without noticing that the pty echoes the command containing
it — so the loop ended thirteen bytes in, having measured nothing. A test that
passes against a bug it was written to catch is worse than no test.

Closes #29.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

