### PR TITLE
Save connections, and start from a list of them

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ against vectors computed outside it. 49 in total.
 **Transport**: RFC 4251 §5 for the wire types, RFC 4253 §6 for the packet
 framing and §7.1 for algorithm negotiation, RFC 8731 §3 for the exchange hash
 and RFC 4253 §7.2 for key derivation, plus base64, host key parsing, the
-version exchange, the chacha20-poly1305 packet layer, UTF-8, host key trust
-and the paths that have to reject malformed input. 99 in total. They run under a Turkish default locale, which is the device's own and
+version exchange, the chacha20-poly1305 packet layer, UTF-8, host key trust,
+saved connections and the paths that have to reject malformed input. 106 in
+total. They run under a Turkish default locale, which is the device's own and
 the setting most likely to break protocol code without raising an error
 anywhere.
 
@@ -156,6 +157,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] VT320 terminal emulation, and a bitmap font renderer
 - [x] A MIDlet that connects, authenticates and runs a shell
 - [x] Runs on a Bold 9790: connects, authenticates, opens a shell
+- [x] Saved connections, host key confirmation, and a transport two threads can share
 - [ ] Keyboard mapping confirmed against the hardware's real key codes
 
 ## Prior art

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")"
 
 NAME=berryssh
 VENDOR="berryssh"
-VERSION=0.1.2
+VERSION=0.2.0
 MIDLET_CLASS=berryssh.device.BerrysshMIDlet
 
 OUT=out

--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -1,3 +1,4 @@
+import berryssh.device.Profile;
 import berryssh.protocol.Ascii;
 import berryssh.protocol.Base64;
 import berryssh.protocol.HostKey;
@@ -59,6 +60,7 @@ public class TransportTests {
         encryptedFraming();
         utf8Vectors();
         knownHostsPolicy();
+        savedConnections();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -755,6 +757,58 @@ public class TransportTests {
         public void store(String host, int port, byte[] blob) {
             entries.put(host + ":" + port, blob);
         }
+    }
+
+    /**
+     * Saved connections, on the encoding side.
+     *
+     * The store itself is RMS and only exists on the device, so what is worth
+     * testing here is what goes into a record and what comes back out.
+     */
+    private static void savedConnections() {
+        try {
+            Profile full = new Profile("work", "example.org", 2222, "cobanov", "sifre", true);
+            Profile back = Profile.decode(full.encode());
+            checkTrue("a saved connection round trips",
+                "work".equals(back.name())
+                    && "example.org".equals(back.host())
+                    && back.port() == 2222
+                    && "cobanov".equals(back.user())
+                    && "sifre".equals(back.password())
+                    && back.savePassword());
+
+            // The password is left out of the record rather than written and
+            // hidden behind a flag: a flag protects nobody who reads the record.
+            Profile unsaved = new Profile("home", "example.org", 22, "bb", "secret", false);
+            Profile storedUnsaved = Profile.decode(unsaved.encode());
+            checkTrue("a password that was not to be saved is not in the record",
+                storedUnsaved.password().length() == 0 && !storedUnsaved.savePassword());
+            checkTrue("the unsaved password is absent from the bytes",
+                toHex(unsaved.encode()).indexOf(toHex(Ascii.toBytes("secret"))) < 0);
+
+            // UTF-8 throughout: the device's default encoding would mangle both
+            // of these, and neither is hypothetical for this user.
+            Profile turkish = new Profile("işyeri", "sunucu.example.org", 22,
+                "çağrı", "parolağı", true);
+            Profile turkishBack = Profile.decode(turkish.encode());
+            checkTrue("Turkish characters survive a save and a load",
+                "işyeri".equals(turkishBack.name())
+                    && "çağrı".equals(turkishBack.user())
+                    && "parolağı".equals(turkishBack.password()));
+
+            checkTrue("the list label identifies the server",
+                full.label().indexOf("cobanov@example.org:2222") >= 0);
+            checkTrue("the default port is left out of the label",
+                new Profile("", "example.org", 22, "bb", "", false)
+                    .label().indexOf(":22") < 0);
+        } catch (IOException e) {
+            fail("saved connection round trip threw " + e);
+        }
+
+        // A record from a version that is not this one is refused rather than
+        // read with its fields in the wrong order.
+        checkRejected("a saved connection in an unknown format is refused",
+            () -> Profile.decode(hex("0000009900000000")));
     }
 
     private static byte[] slice(byte[] b, int offset, int length) {

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -8,11 +8,14 @@ import javax.microedition.io.Connector;
 import javax.microedition.io.SocketConnection;
 import javax.microedition.lcdui.Alert;
 import javax.microedition.lcdui.AlertType;
+import javax.microedition.lcdui.Choice;
+import javax.microedition.lcdui.ChoiceGroup;
 import javax.microedition.lcdui.Command;
 import javax.microedition.lcdui.CommandListener;
 import javax.microedition.lcdui.Display;
 import javax.microedition.lcdui.Displayable;
 import javax.microedition.lcdui.Form;
+import javax.microedition.lcdui.List;
 import javax.microedition.lcdui.TextField;
 import javax.microedition.midlet.MIDlet;
 
@@ -32,6 +35,9 @@ import berryssh.terminal.VT320;
  * Everything below this class is plain MIDP and CLDC and touches no RIM API,
  * which is the whole point: code that never reaches a protected API needs no
  * BlackBerry signature, and the authority that issued those no longer exists.
+ * That also rules out BlackBerry's own UI framework — these are MIDP screens,
+ * which the device draws in its own theme but which are not, and cannot be,
+ * the native widgets.
  *
  * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
  */
@@ -41,10 +47,27 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private static final int CELL_WIDTH = 8;
     private static final int CELL_HEIGHT = 14;
 
-    private final Command connect = new Command("Connect", Command.OK, 1);
-    private final Command quit = new Command("Quit", Command.EXIT, 2);
+    private static final String NEW_CONNECTION = "New connection...";
+
+    // The connection list
+    private final Command connect = new Command("Connect", Command.ITEM, 1);
+    private final Command newConnection = new Command("New", Command.SCREEN, 2);
+    private final Command edit = new Command("Edit", Command.SCREEN, 3);
+    private final Command delete = new Command("Delete", Command.SCREEN, 4);
+    private final Command quit = new Command("Quit", Command.EXIT, 9);
+
+    // The editor
+    private final Command save = new Command("Save", Command.OK, 1);
+    private final Command back = new Command("Back", Command.BACK, 2);
+
+    // The password prompt
+    private final Command go = new Command("Connect", Command.OK, 1);
+
+    // The host key prompt
     private final Command acceptKey = new Command("Accept", Command.OK, 1);
     private final Command rejectKey = new Command("Reject", Command.CANCEL, 2);
+
+    // The terminal
     private final Command control = new Command("Ctrl", Command.SCREEN, 1);
     private final Command escape = new Command("Esc", Command.SCREEN, 2);
     private final Command keys = new Command("Keys", Command.SCREEN, 3);
@@ -53,18 +76,29 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private final Command disconnect = new Command("Disconnect", Command.STOP, 6);
 
     private Display display;
-    private Form setup;
+    private List connections;
+    private Profile[] profiles = new Profile[0];
+
+    private Form editor;
+    private TextField nameField;
     private TextField hostField;
     private TextField portField;
     private TextField userField;
     private TextField passwordField;
+    private ChoiceGroup savePasswordChoice;
+    private String editingName;
+
+    private TextField promptPassword;
+    private Profile pendingProfile;
 
     private TerminalCanvas canvas;
     private Keyboard keyboard;
     private VT320 terminal;
+    private Profile current;
 
     private final EntropyPool random = new EntropyPool();
     private final RecordStoreHostKeys hostKeys = new RecordStoreHostKeys();
+    private final RecordStoreProfiles store = new RecordStoreProfiles();
 
     private SocketConnection socket;
     private Channel channel;
@@ -72,11 +106,9 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private boolean fullScreenOn;
 
     /**
-     * How the session thread asks the user something and waits for the answer.
-     *
-     * The prompt has to be raised on one thread and answered on another, and
-     * the connection cannot proceed until it is — which is the whole point of a
-     * confirmation.
+     * How the session thread asks the user something and waits for an answer.
+     * The question is raised on one thread and answered on another, and the
+     * connection cannot proceed until it is — which is what a confirmation is.
      */
     private final Object promptLock = new Object();
     private Boolean promptAnswer;
@@ -87,33 +119,24 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         }
         display = Display.getDisplay(this);
 
-        // Seeding costs about a tenth of a second and needs doing before any
-        // key material is asked for. Doing it here rather than at connect time
-        // spends it while the user is still typing a hostname.
+        // Seeding costs about a tenth of a second and has to happen before any
+        // key material is asked for. Doing it here spends it while the user is
+        // still choosing a connection.
         new Thread(new Runnable() {
             public void run() {
                 random.seed();
             }
         }).start();
 
-        setup = new Form("berryssh");
-        // URL and EMAILADDR both put the device into an input mode that does
-        // not capitalise the first letter. TextField.ANY does, which made
-        // every username start with a capital and need correcting by hand.
-        hostField = new TextField("Host", "", 64,
-            TextField.URL | TextField.NON_PREDICTIVE);
-        portField = new TextField("Port", "22", 5, TextField.NUMERIC);
-        userField = new TextField("User", "", 32,
-            TextField.EMAILADDR | TextField.NON_PREDICTIVE);
-        passwordField = new TextField("Password", "", 64, TextField.PASSWORD);
-        setup.append(hostField);
-        setup.append(portField);
-        setup.append(userField);
-        setup.append(passwordField);
-        setup.addCommand(connect);
-        setup.addCommand(quit);
-        setup.setCommandListener(this);
-        display.setCurrent(setup);
+        connections = new List("berryssh", Choice.IMPLICIT);
+        connections.addCommand(connect);
+        connections.addCommand(newConnection);
+        connections.addCommand(edit);
+        connections.addCommand(delete);
+        connections.addCommand(quit);
+        connections.setCommandListener(this);
+        refreshConnections();
+        display.setCurrent(connections);
     }
 
     protected void pauseApp() {
@@ -123,16 +146,97 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         shutdown();
     }
 
+    private void refreshConnections() {
+        try {
+            profiles = store.list();
+        } catch (IOException e) {
+            profiles = new Profile[0];
+        }
+        connections.deleteAll();
+        for (int i = 0; i < profiles.length; i++) {
+            connections.append(profiles[i].label(), null);
+        }
+        connections.append(NEW_CONNECTION, null);
+    }
+
+    /** The profile the list is pointing at, or null for the New entry. */
+    private Profile selected() {
+        int index = connections.getSelectedIndex();
+        if (index < 0 || index >= profiles.length) {
+            return null;
+        }
+        return profiles[index];
+    }
+
     public void commandAction(Command command, Displayable from) {
         if (command == quit) {
             shutdown();
             notifyDestroyed();
             return;
         }
-        if (command == connect) {
-            startSession();
+
+        if (from == connections) {
+            if (command == List.SELECT_COMMAND || command == connect) {
+                Profile profile = selected();
+                if (profile == null) {
+                    showEditor(null);
+                } else {
+                    begin(profile);
+                }
+                return;
+            }
+            if (command == newConnection) {
+                showEditor(null);
+                return;
+            }
+            if (command == edit) {
+                showEditor(selected());
+                return;
+            }
+            if (command == delete) {
+                Profile profile = selected();
+                if (profile != null) {
+                    try {
+                        store.delete(profile.name());
+                    } catch (IOException e) {
+                        show("Could not delete: " + e.getMessage(),
+                            AlertType.ERROR, connections);
+                    }
+                    refreshConnections();
+                }
+                return;
+            }
+        }
+
+        if (command == save) {
+            saveEditor();
             return;
         }
+        if (command == back) {
+            pendingProfile = null;
+            refreshConnections();
+            display.setCurrent(connections);
+            return;
+        }
+        if (command == go) {
+            Profile p = pendingProfile;
+            pendingProfile = null;
+            if (p != null) {
+                start(new Profile(p.name(), p.host(), p.port(), p.user(),
+                    promptPassword.getString(), false));
+            }
+            return;
+        }
+
+        if (command == acceptKey || command == rejectKey) {
+            synchronized (promptLock) {
+                promptAnswer = (command == acceptKey) ? Boolean.TRUE : Boolean.FALSE;
+                promptLock.notifyAll();
+            }
+            display.setCurrent(canvas);
+            return;
+        }
+
         // The keyboard only exists once a session has attached one, and these
         // commands are in the menu from the moment the screen appears.
         if (command == control) {
@@ -160,39 +264,105 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         }
         if (command == reconnect) {
             shutdown();
-            startSession();
-            return;
-        }
-        if (command == acceptKey || command == rejectKey) {
-            synchronized (promptLock) {
-                promptAnswer = (command == acceptKey) ? Boolean.TRUE : Boolean.FALSE;
-                promptLock.notifyAll();
+            if (current != null) {
+                start(current);
             }
-            display.setCurrent(canvas);
             return;
         }
         if (command == disconnect) {
             shutdown();
-            display.setCurrent(setup);
+            refreshConnections();
+            display.setCurrent(connections);
         }
     }
 
-    private void startSession() {
-        final String host = hostField.getString().trim();
-        final int port = parsePort(portField.getString());
-        final String user = userField.getString().trim();
-        final String password = passwordField.getString();
+    private void showEditor(Profile profile) {
+        editingName = profile == null ? null : profile.name();
+        editor = new Form(profile == null ? "New connection" : "Edit connection");
 
+        nameField = new TextField("Name", profile == null ? "" : profile.name(),
+            32, TextField.ANY);
+        // URL and EMAILADDR put the device into an input mode that does not
+        // capitalise the first letter. TextField.ANY does, which made every
+        // host and user name start with a capital and need correcting by hand
+        // on a keyboard where that is several presses.
+        hostField = new TextField("Host", profile == null ? "" : profile.host(),
+            64, TextField.URL | TextField.NON_PREDICTIVE);
+        portField = new TextField("Port", profile == null ? "22" : "" + profile.port(),
+            5, TextField.NUMERIC);
+        userField = new TextField("User", profile == null ? "" : profile.user(),
+            32, TextField.EMAILADDR | TextField.NON_PREDICTIVE);
+        passwordField = new TextField("Password",
+            profile == null ? "" : profile.password(), 64, TextField.PASSWORD);
+        savePasswordChoice = new ChoiceGroup("", Choice.MULTIPLE,
+            new String[] { "Save password (not encrypted)" }, null);
+        savePasswordChoice.setSelectedIndex(0, profile != null && profile.savePassword());
+
+        editor.append(nameField);
+        editor.append(hostField);
+        editor.append(portField);
+        editor.append(userField);
+        editor.append(passwordField);
+        editor.append(savePasswordChoice);
+        editor.addCommand(save);
+        editor.addCommand(back);
+        editor.setCommandListener(this);
+        display.setCurrent(editor);
+    }
+
+    private void saveEditor() {
+        String host = hostField.getString().trim();
+        String user = userField.getString().trim();
         if (host.length() == 0 || user.length() == 0) {
-            show("A host and a user are needed.", AlertType.WARNING, setup);
+            show("A host and a user are needed.", AlertType.WARNING, editor);
             return;
         }
+        String name = nameField.getString().trim();
+        if (name.length() == 0) {
+            name = host;
+        }
+
+        Profile profile = new Profile(name, host, parsePort(portField.getString()),
+            user, passwordField.getString(), savePasswordChoice.isSelected(0));
+        try {
+            // Renaming replaces rather than duplicating.
+            if (editingName != null && !editingName.equals(name)) {
+                store.delete(editingName);
+            }
+            store.save(profile);
+        } catch (IOException e) {
+            show("Could not save: " + e.getMessage(), AlertType.ERROR, editor);
+            return;
+        }
+        refreshConnections();
+        display.setCurrent(connections);
+    }
+
+    /** Connects, asking for the password first when none was saved. */
+    private void begin(Profile profile) {
+        if (profile.savePassword() && profile.password().length() > 0) {
+            start(profile);
+            return;
+        }
+        pendingProfile = profile;
+        Form prompt = new Form(profile.user() + "@" + profile.host());
+        promptPassword = new TextField("Password", "", 64, TextField.PASSWORD);
+        prompt.append(promptPassword);
+        prompt.addCommand(go);
+        prompt.addCommand(back);
+        prompt.setCommandListener(this);
+        display.setCurrent(prompt);
+    }
+
+    private void start(final Profile profile) {
+        current = profile;
 
         BitmapFont font;
         try {
             font = BitmapFont.load(FONT, CELL_WIDTH, CELL_HEIGHT);
         } catch (IOException e) {
-            show("The font atlas is missing: " + e.getMessage(), AlertType.ERROR, setup);
+            show("The font atlas is missing: " + e.getMessage(),
+                AlertType.ERROR, connections);
             return;
         }
 
@@ -203,12 +373,11 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         canvas.addCommand(fullScreen);
         canvas.addCommand(reconnect);
         canvas.addCommand(disconnect);
-        // Quit belongs on this screen too. Reaching it only from the setup
-        // form means a session that will not disconnect cleanly is a session
-        // you cannot leave.
+        // Quit belongs on this screen too. Reaching it only from the list means
+        // a session that will not disconnect cleanly is one you cannot leave.
         canvas.addCommand(quit);
         canvas.setCommandListener(this);
-        canvas.setStatus("connecting to " + host + "...");
+        canvas.setStatus("connecting to " + profile.host() + "...");
         display.setCurrent(canvas);
 
         // Networking must not run on the event thread: on this platform the
@@ -217,12 +386,14 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         running = true;
         new Thread(new Runnable() {
             public void run() {
-                runSession(host, port, user, password);
+                runSession(profile);
             }
         }).start();
     }
 
-    private void runSession(String host, int port, String user, String password) {
+    private void runSession(Profile profile) {
+        String host = profile.host();
+        int port = profile.port();
         try {
             random.seed();
 
@@ -254,10 +425,10 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
                 KnownHosts.accept(hostKeys, host, port, key);
             }
 
-            UserAuth auth = new UserAuth(connection, user);
+            UserAuth auth = new UserAuth(connection, profile.user());
             auth.begin();
             auth.queryMethods();
-            if (!auth.password(password).succeeded()) {
+            if (!auth.password(profile.password()).succeeded()) {
                 fail("Authentication failed.");
                 return;
             }
@@ -285,7 +456,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             };
             keyboard = new Keyboard(terminal);
             canvas.attach(terminal, keyboard);
-            canvas.setStatus(user + "@" + host + "  " + columns + "x" + rows);
+            canvas.setStatus(profile.user() + "@" + host + "  " + columns + "x" + rows);
 
             session.requestPty("xterm", columns, rows);
             session.requestShell();
@@ -296,8 +467,6 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
                 if (n < 0) {
                     break;
                 }
-                // The device's default encoding is ISO8859_1, so the decode is
-                // ours to do. See Utf8.
                 // The painter reads this buffer from the event thread while
                 // this thread writes it. VT320 publishes a mutex for exactly
                 // that, and using it is the difference between a redraw during
@@ -323,11 +492,6 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
      * that route is gone — BIS was switched off, and MDS needs an enterprise
      * server — so the connection has to say Wi-Fi explicitly. The suffixes are
      * URL parameters rather than an API, so they cost nothing in signing terms.
-     *
-     * They are tried in order rather than assumed, because which one a given
-     * OS 7 build accepts has not been established on the hardware here. The one
-     * that works is reported on the status line, so the first real connection
-     * also settles the question.
      */
     private SocketConnection openSocket(String host, int port) throws IOException {
         String address = "socket://" + host + ":" + port;
@@ -353,13 +517,6 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             + " (last error: " + (last == null ? "none" : last.getMessage()) + ")");
     }
 
-    /**
-     * Reports a fault, unless we caused it.
-     *
-     * Disconnecting closes the socket under a reader that is blocked on it, so
-     * the read fails by design. Showing that as an error would put a warning in
-     * front of a user who just chose to leave.
-     */
     /**
      * Puts a question to the user and blocks until it is answered.
      *
@@ -387,12 +544,19 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         }
     }
 
+    /**
+     * Reports a fault, unless we caused it.
+     *
+     * Disconnecting closes the socket under a reader that is blocked on it, so
+     * the read fails by design. Showing that as an error would put a warning in
+     * front of a user who just chose to leave.
+     */
     private void fail(final String message) {
         if (!running) {
             return;
         }
         canvas.setStatus("");
-        show(message, AlertType.ERROR, setup);
+        show(message, AlertType.ERROR, connections);
     }
 
     private void show(String message, AlertType type, Displayable next) {
@@ -414,7 +578,9 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         }
         int columns = canvas.columns();
         int rows = canvas.rows();
-        terminal.setScreenSize(columns, rows, true);
+        synchronized (terminal.getTermBufferMutex()) {
+            terminal.setScreenSize(columns, rows, true);
+        }
         try {
             channel.windowChange(columns, rows);
         } catch (IOException e) {

--- a/ssh/src/berryssh/device/Profile.java
+++ b/ssh/src/berryssh/device/Profile.java
@@ -1,0 +1,122 @@
+package berryssh.device;
+
+import java.io.IOException;
+
+import berryssh.protocol.SshException;
+import berryssh.protocol.Utf8;
+import berryssh.protocol.WireReader;
+import berryssh.protocol.WireWriter;
+
+/**
+ * A saved connection.
+ *
+ * Deliberately free of MIDP, so that the encoding — the part with rules in it —
+ * can be tested on the host. {@link Store} is where the device comes in.
+ *
+ * Everything is UTF-8 on the way in and out. A host name or a password with a
+ * Turkish letter in it is not an edge case for this user, and the device's
+ * default encoding would silently mangle both.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Profile {
+
+    /** Where profiles are kept. Implemented over RMS on the device. */
+    public interface Store {
+        Profile[] list() throws IOException;
+
+        void save(Profile profile) throws IOException;
+
+        void delete(String name) throws IOException;
+    }
+
+    private static final int FORMAT = 1;
+
+    private final String name;
+    private final String host;
+    private final int port;
+    private final String user;
+    private final String password;
+    private final boolean savePassword;
+
+    public Profile(String name, String host, int port, String user,
+                   String password, boolean savePassword) {
+        this.name = name;
+        this.host = host;
+        this.port = port;
+        this.user = user;
+        this.password = password == null ? "" : password;
+        this.savePassword = savePassword;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String host() {
+        return host;
+    }
+
+    public int port() {
+        return port;
+    }
+
+    public String user() {
+        return user;
+    }
+
+    /** Empty unless a password was saved. */
+    public String password() {
+        return password;
+    }
+
+    public boolean savePassword() {
+        return savePassword;
+    }
+
+    /** What the connection list shows: enough to tell two servers apart. */
+    public String label() {
+        String where = user + "@" + host;
+        if (port != 22) {
+            where = where + ":" + port;
+        }
+        return name.length() > 0 ? name + "  (" + where + ")" : where;
+    }
+
+    /**
+     * Serialises for storage.
+     *
+     * The password is written only when it was meant to be kept. Storing it and
+     * relying on a flag to hide it would leave it on the device for anyone who
+     * read the record rather than the field.
+     */
+    public byte[] encode() {
+        WireWriter w = new WireWriter(256);
+        w.writeUint32(FORMAT);
+        w.writeString(Utf8.encode(name));
+        w.writeString(Utf8.encode(host));
+        w.writeUint32(port);
+        w.writeString(Utf8.encode(user));
+        w.writeBoolean(savePassword);
+        w.writeString(Utf8.encode(savePassword ? password : ""));
+        return w.toByteArray();
+    }
+
+    public static Profile decode(byte[] record) throws IOException {
+        WireReader r = new WireReader(record);
+        long format = r.readUint32();
+        if (format != FORMAT) {
+            // A record written by a version that is not this one. Refusing it
+            // is better than reading its fields in the wrong order.
+            throw new SshException("saved connection is in format " + format
+                + ", not " + FORMAT);
+        }
+        String name = Utf8.decode(r.readString());
+        String host = Utf8.decode(r.readString());
+        int port = (int) r.readUint32();
+        String user = Utf8.decode(r.readString());
+        boolean savePassword = r.readBoolean();
+        String password = Utf8.decode(r.readString());
+        return new Profile(name, host, port, user, password, savePassword);
+    }
+}

--- a/ssh/src/berryssh/device/RecordStoreProfiles.java
+++ b/ssh/src/berryssh/device/RecordStoreProfiles.java
@@ -1,0 +1,111 @@
+package berryssh.device;
+
+import java.io.IOException;
+
+import javax.microedition.rms.RecordEnumeration;
+import javax.microedition.rms.RecordStore;
+import javax.microedition.rms.RecordStoreException;
+
+import berryssh.protocol.SshException;
+
+/**
+ * Saved connections, in RMS.
+ *
+ * The same arrangement as {@link RecordStoreHostKeys}: RMS is MIDP rather than
+ * RIM, so it needs no signature, and its records are private to this MIDlet.
+ *
+ * <b>Not encrypted.</b> A saved password is protected by the handset's own lock
+ * and by nothing else. That is a real limit and the UI says so rather than
+ * implying otherwise — CLDC has no key store to do better with, and inventing
+ * an encryption scheme whose key would have to live beside the data would be
+ * theatre.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class RecordStoreProfiles implements Profile.Store {
+
+    private static final String STORE_NAME = "berryssh_connections";
+
+    public Profile[] list() throws IOException {
+        RecordStore store = open();
+        try {
+            RecordEnumeration records = store.enumerateRecords(null, null, false);
+            Profile[] found = new Profile[store.getNumRecords()];
+            int n = 0;
+            while (records.hasNextElement()) {
+                byte[] record = records.nextRecord();
+                try {
+                    found[n++] = Profile.decode(record);
+                } catch (IOException e) {
+                    // A record this version cannot read is skipped rather than
+                    // fatal: one unreadable entry should not cost the others.
+                    n--;
+                }
+            }
+            Profile[] exact = new Profile[n];
+            System.arraycopy(found, 0, exact, 0, n);
+            return exact;
+        } catch (RecordStoreException e) {
+            throw new SshException("could not read saved connections: " + e.getMessage());
+        } finally {
+            close(store);
+        }
+    }
+
+    /** Saves, replacing any profile of the same name. */
+    public void save(Profile profile) throws IOException {
+        RecordStore store = open();
+        try {
+            deleteMatching(store, profile.name());
+            byte[] record = profile.encode();
+            store.addRecord(record, 0, record.length);
+        } catch (RecordStoreException e) {
+            throw new SshException("could not save the connection: " + e.getMessage());
+        } finally {
+            close(store);
+        }
+    }
+
+    public void delete(String name) throws IOException {
+        RecordStore store = open();
+        try {
+            deleteMatching(store, name);
+        } catch (RecordStoreException e) {
+            throw new SshException("could not delete the connection: " + e.getMessage());
+        } finally {
+            close(store);
+        }
+    }
+
+    private static void deleteMatching(RecordStore store, String name)
+            throws RecordStoreException {
+        RecordEnumeration records = store.enumerateRecords(null, null, false);
+        while (records.hasNextElement()) {
+            int id = records.nextRecordId();
+            try {
+                if (name.equals(Profile.decode(store.getRecord(id)).name())) {
+                    store.deleteRecord(id);
+                }
+            } catch (IOException e) {
+                // Unreadable, so not the one being replaced. Left alone.
+            }
+        }
+    }
+
+    private static RecordStore open() throws IOException {
+        try {
+            return RecordStore.openRecordStore(STORE_NAME, true);
+        } catch (RecordStoreException e) {
+            throw new SshException("could not open saved connections: " + e.getMessage());
+        }
+    }
+
+    private static void close(RecordStore store) {
+        try {
+            store.closeRecordStore();
+        } catch (RecordStoreException e) {
+            // The records are already written; throwing here would replace a
+            // real error with a cosmetic one.
+        }
+    }
+}


### PR DESCRIPTION
Save connections, and start from a list of them

Every launch asked for host, port, user and password, typed on a phone
keyboard. That is the difference between something that works and something
anyone would use, and it was the largest gap left.

**The screens**

The application now opens on the list of saved connections. Selecting one
connects. New, Edit and Delete are on the same screen, and the editor holds
name, host, port, user, password and a checkbox for whether to keep the
password.

MIDP screens, not BlackBerry ones. The native UI framework is
net.rim.device.api.ui, which is a protected API and therefore the one thing
this project cannot touch — a signature would be required, from an authority
that no longer exists. The device draws MIDP forms in its own theme, so they
look close, but they are not the native widgets and cannot be.

**The password**

Saving it is optional and off unless asked for. When it is off the password is
not written to the record at all, rather than written and hidden behind a flag
— a flag protects nobody who reads the record instead of the field. When it is
on, the label says "not encrypted", because that is the truth: RMS records are
private to this MIDlet but are not encrypted, and a saved password is protected
by the handset's lock and nothing else. CLDC has no key store to do better
with, and encrypting with a key that would have to live beside the data would
be theatre.

**Structure**

The same split as the host keys: `Profile` holds the data and the encoding and
touches no MIDP, so the part with rules in it is tested on the host;
`RecordStoreProfiles` is the RMS half. The tests cover the round trip, the
absent password, and Turkish text surviving both ways — the last is not a
hypothetical for this user, and the device's default encoding would mangle it.

A record written in a format this version does not know is refused rather than
read with its fields in the wrong order, and one unreadable record does not
cost the others.

Also stops the host and user fields capitalising their first letter, which had
to be corrected by hand on every login.

Closes #31.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

