### PR TITLE
Add scrollback

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")"
 
 NAME=berryssh
 VENDOR="berryssh"
-VERSION=0.2.0
+VERSION=0.2.1
 MIDLET_CLASS=berryssh.device.BerrysshMIDlet
 
 OUT=out

--- a/spike2/src/TerminalTests.java
+++ b/spike2/src/TerminalTests.java
@@ -30,6 +30,7 @@ public class TerminalTests {
         scrolls();
         sendsKeys();
         dispatchesKeys();
+        keepsScrollback();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -190,6 +191,47 @@ public class TerminalTests {
         // this the one letter of the alphabet that stopped working.
         checkTrue("Ctrl-I is Tab under any locale", Keyboard.controlOf('i') == 9);
         checkTrue("Ctrl-I is Tab from the capital too", Keyboard.controlOf('I') == 9);
+    }
+
+    /**
+     * Scrollback, which the emulator does not have until it is asked for.
+     *
+     * The constructor sizes the buffer to the screen, so a terminal built and
+     * left alone keeps nothing: paging up would show the screen already on
+     * display. This is the mechanism the canvas reads through, checked here
+     * because the canvas itself needs MIDP and cannot run on the host.
+     */
+    private static void keepsScrollback() {
+        Headless plain = new Headless(20, 4);
+        plain.putString("one\r\ntwo\r\nthree\r\nfour\r\nfive\r\n");
+        checkTrue("without asking, nothing is kept above the screen",
+            plain.screenBase == 0);
+
+        Headless t = new Headless(20, 4);
+        t.setScrollbackBufferSize(100);
+        for (int i = 1; i <= 40; i++) {
+            t.putString("line" + i + "\r\n");
+        }
+
+        checkTrue("history accumulates above the live screen", t.screenBase > 0);
+
+        // The live screen still shows the end.
+        checkTrue("the live screen is the most recent output",
+            "line40".equals(row(t, 2, 6)));
+
+        // And the buffer holds what scrolled past, which is what the canvas
+        // reads when it pages up.
+        boolean foundEarlier = false;
+        for (int line = 0; line < t.screenBase; line++) {
+            StringBuffer sb = new StringBuffer();
+            for (int c = 0; c < 6; c++) {
+                sb.append((char) t.terminalData[line][c]);
+            }
+            if ("line10".equals(sb.toString())) {
+                foundEarlier = true;
+            }
+        }
+        checkTrue("a line that scrolled off is still in the buffer", foundEarlier);
     }
 
     /** Feeds one key through the dispatcher and returns what reached the wire. */

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -49,6 +49,13 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
 
     private static final String NEW_CONNECTION = "New connection...";
 
+    /**
+     * Lines kept above the screen. The device measured ~357 MB of free heap and
+     * a line is a few hundred bytes, so this is nothing — and a terminal that
+     * cannot show what just scrolled past is barely a terminal on 24 rows.
+     */
+    private static final int SCROLLBACK_LINES = 500;
+
     // The connection list
     private final Command connect = new Command("Connect", Command.ITEM, 1);
     private final Command newConnection = new Command("New", Command.SCREEN, 2);
@@ -70,10 +77,12 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     // The terminal
     private final Command control = new Command("Ctrl", Command.SCREEN, 1);
     private final Command escape = new Command("Esc", Command.SCREEN, 2);
-    private final Command keys = new Command("Keys", Command.SCREEN, 3);
-    private final Command fullScreen = new Command("Full screen", Command.SCREEN, 4);
-    private final Command reconnect = new Command("Reconnect", Command.SCREEN, 5);
-    private final Command disconnect = new Command("Disconnect", Command.STOP, 6);
+    private final Command pageUp = new Command("Page up", Command.SCREEN, 3);
+    private final Command pageDown = new Command("Page down", Command.SCREEN, 4);
+    private final Command keys = new Command("Keys", Command.SCREEN, 5);
+    private final Command fullScreen = new Command("Full screen", Command.SCREEN, 6);
+    private final Command reconnect = new Command("Reconnect", Command.SCREEN, 7);
+    private final Command disconnect = new Command("Disconnect", Command.STOP, 8);
 
     private Display display;
     private List connections;
@@ -252,6 +261,14 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             }
             return;
         }
+        if (command == pageUp) {
+            canvas.pageUp();
+            return;
+        }
+        if (command == pageDown) {
+            canvas.pageDown();
+            return;
+        }
         if (command == keys) {
             canvas.toggleKeyCodes();
             return;
@@ -369,6 +386,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         canvas = new TerminalCanvas(font);
         canvas.addCommand(control);
         canvas.addCommand(escape);
+        canvas.addCommand(pageUp);
+        canvas.addCommand(pageDown);
         canvas.addCommand(keys);
         canvas.addCommand(fullScreen);
         canvas.addCommand(reconnect);
@@ -454,6 +473,10 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
                 public void resize() {
                 }
             };
+            // The constructor sizes the buffer to the screen, so without this
+            // there is no scrollback at all and paging up would show the screen
+            // that is already there.
+            terminal.setScrollbackBufferSize(SCROLLBACK_LINES);
             keyboard = new Keyboard(terminal);
             canvas.attach(terminal, keyboard);
             canvas.setStatus(profile.user() + "@" + host + "  " + columns + "x" + rows);

--- a/ssh/src/berryssh/device/TerminalCanvas.java
+++ b/ssh/src/berryssh/device/TerminalCanvas.java
@@ -28,6 +28,9 @@ public final class TerminalCanvas extends Canvas {
     private Keyboard keyboard;
     private String status = "";
 
+    /** Rows above the live screen currently being looked at. Zero is live. */
+    private int scrollOffset;
+
     private boolean shown;
     private boolean showKeyCodes;
     private String lastKey = "";
@@ -124,6 +127,48 @@ public final class TerminalCanvas extends Canvas {
      * can be read off the hardware in the place they matter rather than from a
      * separate probe.
      */
+    /**
+     * Moves the view back through the scrollback, a screen at a time.
+     *
+     * Bounded by what the buffer actually holds rather than by a guess: asking
+     * for a line that was never kept would draw whatever the array happens to
+     * contain there.
+     */
+    public void pageUp() {
+        int available = terminal == null ? 0 : terminal.screenBase;
+        scrollOffset += rows() - 1;
+        if (scrollOffset > available) {
+            scrollOffset = available;
+        }
+        repaint();
+    }
+
+    public void pageDown() {
+        scrollOffset -= rows() - 1;
+        if (scrollOffset < 0) {
+            scrollOffset = 0;
+        }
+        repaint();
+    }
+
+    /**
+     * Returns to the live screen.
+     *
+     * Called whenever a key is typed. Reading history and then typing blind
+     * into a screen that is not the one being shown is worse than not being
+     * able to scroll at all.
+     */
+    public void toLive() {
+        if (scrollOffset != 0) {
+            scrollOffset = 0;
+            repaint();
+        }
+    }
+
+    public boolean isScrolledBack() {
+        return scrollOffset > 0;
+    }
+
     public void toggleKeyCodes() {
         showKeyCodes = !showKeyCodes;
         repaint();
@@ -150,9 +195,22 @@ public final class TerminalCanvas extends Canvas {
             // half-drawn frame, which would tear the picture and, during a
             // resize, index past the end of it.
             synchronized (terminal.getTermBufferMutex()) {
+                // getChar always reads the live screen, so the scrollback is
+                // read from the buffer directly at an offset. The character is
+                // the low half of each cell; the high half is its attributes.
+                int base = terminal.screenBase - scrollOffset;
+                if (base < 0) {
+                    base = 0;
+                }
+                long[][] data = terminal.terminalData;
                 for (int row = 0; row < rows; row++) {
-                    for (int column = 0; column < columns; column++) {
-                        char c = terminal.getChar(column, row);
+                    int line = base + row;
+                    if (data == null || line < 0 || line >= data.length) {
+                        continue;
+                    }
+                    long[] cells = data[line];
+                    for (int column = 0; column < columns && column < cells.length; column++) {
+                        char c = (char) cells[column];
                         if (c > 32) {
                             font.drawChar(g, c,
                                 column * font.cellWidth(), row * font.cellHeight());
@@ -168,6 +226,12 @@ public final class TerminalCanvas extends Canvas {
         String line = showKeyCodes ? lastKey : status;
         if (keyboard != null && keyboard.controlPending()) {
             line = "^ " + line;
+        }
+        // An old screen and a live one look exactly alike, so say which this
+        // is. Without it, output arriving while scrolled back looks like a
+        // terminal that has stopped responding.
+        if (scrollOffset > 0) {
+            line = "-" + scrollOffset + " " + line;
         }
         font.setColours(STATUS, BACKGROUND);
         int y = height - font.cellHeight();
@@ -205,6 +269,7 @@ public final class TerminalCanvas extends Canvas {
             + " grid " + columns() + "x" + rows();
 
         if (keyboard != null) {
+            toLive();
             keyboard.keyPressed(keyCode, action);
         }
         repaint();


### PR DESCRIPTION
Add scrollback

The screen holds 24 rows, so anything longer — a build log, dmesg, a directory
listing — scrolled past and was gone. On a screen this size that is not a
convenience feature.

Three parts, and the first is the one that would have made the other two look
broken. VT320's constructor sizes its buffer to the screen, so a terminal left
alone keeps no history at all: paging up would have redrawn the screen already
on display, which looks like a bug in the paging rather than an absent buffer.
The session now asks for 500 lines. The device measured about 357 MB of free
heap and a line is a few hundred bytes, so the cost is nothing.

Reading it needs the buffer directly. getChar always reads the live screen, so
the canvas takes the character out of the backing array at an offset — the
character is the low half of each cell and its attributes the high half — and
bounds the offset by what the buffer actually holds rather than by a guess,
since asking for a line that was never kept would draw whatever happens to be
in the array at that index.

Typing returns to the live screen. Reading history and then typing blind into a
screen that is not the one being shown is worse than not being able to scroll
at all. And the status line says how far back the view is, because an old
screen and a current one look exactly alike — without that, output arriving
while scrolled back looks like a terminal that has stopped responding.

Tested on the host, including the case that motivates the first part: a
terminal that was never asked for scrollback keeps nothing, and one that was
keeps a line that has scrolled off.

Closes #32.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

