### PR TITLE
Survive a rekey, and render colour and a cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ convinces an OpenSSH server or it does not, so the other half of the
 verification talks to one:
 
 ```sh
+tools/rekey-server.sh             # a second server that rekeys every 64 KB
 spike2/against-server.sh          # defaults to the project's container
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")"
 
 NAME=berryssh
 VENDOR="berryssh"
-VERSION=0.3.0
+VERSION=0.3.1
 MIDLET_CLASS=berryssh.device.BerrysshMIDlet
 
 OUT=out

--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -33,6 +33,7 @@ public class ServerTests {
     private static int port = 2222;
     private static String user = "bb";
     private static String password = "bbssh";
+    private static int rekeyPort = 2223;
 
     private static int passed;
     private static int failed;
@@ -57,6 +58,7 @@ public class ServerTests {
         runsAShellOnRealServer();
         rendersARealSessionThroughTheTerminal();
         survivesTypingWhileOutputArrives();
+        survivesARekey();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -513,6 +515,99 @@ public class ServerTests {
                 after.append(Utf8.decode(buffer, 0, n));
             }
             checkTrue("the connection still works afterwards",
+                after.toString().indexOf("still-alive") >= 0);
+
+            channel.write(Utf8.encode("exit\n"));
+            channel.close();
+        } finally {
+            socket.close();
+        }
+    }
+
+    /**
+     * A server asking to rekey mid-session.
+     *
+     * OpenSSH does this after about a gigabyte or an hour. Before it was
+     * handled, the KEXINIT reached the channel and the session died with a
+     * complaint about an unexpected message — an hour into a connection, for no
+     * visible reason.
+     *
+     * Waiting an hour is not a test, so this runs against a throwaway server
+     * with RekeyLimit set to 64 KB (tools/rekey-server.sh). It is deliberately
+     * not the shared container: that one is what the handset connects to.
+     */
+    private static void survivesARekey() throws Exception {
+        Socket socket;
+        try {
+            socket = new Socket(host, rekeyPort);
+        } catch (IOException e) {
+            System.out.println("  SKIP  rekey: nothing on " + host + ":" + rekeyPort
+                + " (tools/rekey-server.sh)");
+            return;
+        }
+        try {
+            socket.setSoTimeout(30000);
+            EntropyPool random = new EntropyPool();
+            random.seed();
+            Connection connection = new Connection(
+                socket.getInputStream(), socket.getOutputStream(), random);
+            connection.handshake();
+            byte[] firstSessionId = connection.sessionId();
+
+            UserAuth auth = new UserAuth(connection, user);
+            auth.begin();
+            auth.queryMethods();
+            auth.password(password);
+
+            Channel channel = Channel.openSession(connection);
+            channel.requestPty("xterm", 60, 25);
+            channel.requestShell();
+
+            // Well past 64 KB, so the server asks to rekey more than once.
+            channel.write(Utf8.encode("seq 1 10''0000\n"));
+
+            long total = 0;
+            boolean sawEnd = false;
+            StringBuffer tail = new StringBuffer();
+            byte[] buffer = new byte[4096];
+            while (!sawEnd) {
+                int n = channel.read(buffer, 0, buffer.length);
+                if (n < 0) {
+                    break;
+                }
+                total += n;
+                tail.append(Utf8.decode(buffer, 0, n));
+                if (tail.length() > 4096) {
+                    tail.delete(0, tail.length() - 2048);
+                }
+                if (tail.toString().indexOf("100000") >= 0) {
+                    sawEnd = true;
+                }
+            }
+
+            checkTrue("a session survives the rekeys a 64 KB limit forces",
+                sawEnd && total > 64 * 1024);
+            System.out.println("        " + (total / 1024) + " KB through a "
+                + (total / 65536) + "-rekey session");
+
+            // The session identifier is fixed at the first exchange for the
+            // life of the connection: it is what the authentication signature
+            // was bound to, so replacing it would invalidate it after the fact.
+            checkTrue("the session identifier did not change",
+                sameBytes(firstSessionId, connection.sessionId()));
+
+            channel.write(Utf8.encode("echo st''ill-alive\n"));
+            StringBuffer after = new StringBuffer();
+            long deadline = System.currentTimeMillis() + 15000;
+            while (after.toString().indexOf("still-alive") < 0
+                    && System.currentTimeMillis() < deadline) {
+                int n = channel.read(buffer, 0, buffer.length);
+                if (n < 0) {
+                    break;
+                }
+                after.append(Utf8.decode(buffer, 0, n));
+            }
+            checkTrue("the connection still works after rekeying",
                 after.toString().indexOf("still-alive") >= 0);
 
             channel.write(Utf8.encode("exit\n"));

--- a/ssh/src/berryssh/device/TerminalCanvas.java
+++ b/ssh/src/berryssh/device/TerminalCanvas.java
@@ -23,6 +23,27 @@ public final class TerminalCanvas extends Canvas {
     private static final int FOREGROUND = 0xffffff;
     private static final int STATUS = 0x808080;
 
+    /**
+     * The eight ANSI colours, and their bold forms.
+     *
+     * The xterm values rather than pure primaries: pure blue on black is close
+     * to unreadable, and a terminal spends a lot of its time showing blue.
+     */
+    private static final int[] ANSI = {
+        0x000000, 0xcd0000, 0x00cd00, 0xcdcd00,
+        0x0000ee, 0xcd00cd, 0x00cdcd, 0xe5e5e5
+    };
+    private static final int[] ANSI_BOLD = {
+        0x7f7f7f, 0xff0000, 0x00ff00, 0xffff00,
+        0x5c5cff, 0xff00ff, 0x00ffff, 0xffffff
+    };
+
+    // VT320 packs these into the high half of each cell.
+    private static final int BOLD = 0x01;
+    private static final int INVERT = 0x04;
+    private static final int COLOUR_FOREGROUND = 0x0f0;
+    private static final int COLOUR_BACKGROUND = 0xf00;
+
     private final BitmapFont font;
     private VT320 terminal;
     private Keyboard keyboard;
@@ -210,10 +231,34 @@ public final class TerminalCanvas extends Canvas {
                     }
                     long[] cells = data[line];
                     for (int column = 0; column < columns && column < cells.length; column++) {
-                        char c = (char) cells[column];
+                        long cell = cells[column];
+                        drawCell(g, (char) cell, (int) (cell >>> 32),
+                            column * font.cellWidth(), row * font.cellHeight());
+                    }
+                }
+
+                // The cursor last, so it sits over whatever is beneath it. Not
+                // drawn when the view is scrolled back: it would then point at
+                // a line that is not the one being edited, which is worse than
+                // showing nothing.
+                if (scrollOffset == 0) {
+                    int cursorRow = terminal.ROW;
+                    int cursorColumn = terminal.COLUMN;
+                    if (cursorRow >= 0 && cursorRow < rows
+                            && cursorColumn >= 0 && cursorColumn < columns) {
+                        int x = cursorColumn * font.cellWidth();
+                        int y = cursorRow * font.cellHeight();
+                        int line = base + cursorRow;
+                        char c = ' ';
+                        if (data != null && line >= 0 && line < data.length
+                                && cursorColumn < data[line].length) {
+                            c = (char) data[line][cursorColumn];
+                        }
+                        g.setColor(FOREGROUND);
+                        g.fillRect(x, y, font.cellWidth(), font.cellHeight());
                         if (c > 32) {
-                            font.drawChar(g, c,
-                                column * font.cellWidth(), row * font.cellHeight());
+                            font.setColours(BACKGROUND, FOREGROUND);
+                            font.drawChar(g, c, x, y);
                         }
                     }
                 }
@@ -237,6 +282,42 @@ public final class TerminalCanvas extends Canvas {
         int y = height - font.cellHeight();
         for (int i = 0; i < line.length() && i < columns(); i++) {
             font.drawChar(g, line.charAt(i), i * font.cellWidth(), y);
+        }
+    }
+
+    /**
+     * Draws one cell, in the colours its attributes ask for.
+     *
+     * The background is painted only when it is not the default, since the
+     * whole canvas has already been cleared to that — and a fillRect per cell
+     * across a 60x24 grid is 1440 of them per frame on a handset.
+     */
+    private void drawCell(Graphics g, char c, int attributes, int x, int y) {
+        int foregroundIndex = (attributes & COLOUR_FOREGROUND) >> 4;
+        int backgroundIndex = (attributes & COLOUR_BACKGROUND) >> 8;
+        boolean bold = (attributes & BOLD) != 0;
+
+        // Zero means "whatever the terminal's default is", not colour zero.
+        int foreground = foregroundIndex == 0
+            ? FOREGROUND
+            : (bold ? ANSI_BOLD : ANSI)[foregroundIndex - 1];
+        int background = backgroundIndex == 0
+            ? BACKGROUND
+            : ANSI[backgroundIndex - 1];
+
+        if ((attributes & INVERT) != 0) {
+            int swap = foreground;
+            foreground = background;
+            background = swap;
+        }
+
+        if (background != BACKGROUND) {
+            g.setColor(background);
+            g.fillRect(x, y, font.cellWidth(), font.cellHeight());
+        }
+        if (c > 32) {
+            font.setColours(foreground, background);
+            font.drawChar(g, c, x, y);
         }
     }
 

--- a/ssh/src/berryssh/protocol/Connection.java
+++ b/ssh/src/berryssh/protocol/Connection.java
@@ -17,7 +17,7 @@ import berryssh.crypto.EntropyPool;
  *
  * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
  */
-public final class Connection {
+public final class Connection implements Transport.RekeyHandler {
 
     private final Transport transport;
     private final EntropyPool random;
@@ -89,7 +89,69 @@ public final class Connection {
         transport.decryptIncoming(new PacketCipher(
             result.deriveKey('D', sessionId, PacketCipher.KEY_LENGTH)));
 
+        // Only now. Registered any earlier — in the constructor, as it was —
+        // the server's opening KEXINIT is itself mistaken for a rekey request
+        // and the initial handshake never completes.
+        transport.setRekeyHandler(this);
+
         return hostKey;
+    }
+
+    /**
+     * Runs the key exchange again, at the server's request.
+     *
+     * The session identifier deliberately does not change. RFC 4253 fixes it to
+     * the first exchange hash for the life of the connection, and it is what
+     * the user authentication signature was bound to — replacing it would
+     * retroactively invalidate the thing that proved who we are.
+     *
+     * The send lock is held throughout. Between our NEWKEYS and the server's,
+     * the two directions are on different keys, and a keystroke that slipped
+     * out in the middle would be encrypted under keys the server had already
+     * retired.
+     */
+    public void rekey(byte[] serverKexInit) throws IOException {
+        synchronized (transport.sendLock()) {
+            KexInit ours = KexInit.client(random);
+            transport.writePacket(ours.payload());
+            KexInit theirs = KexInit.parse(serverKexInit);
+
+            Negotiation negotiated = Negotiation.between(ours, theirs);
+            if (negotiated.discardGuessedPacket()) {
+                transport.readMessage();
+            }
+
+            KeyExchange.Result result = KeyExchange.run(transport, ours, theirs, random);
+
+            // The host key must still be the one already trusted. A server that
+            // presents a different one mid-session is not the server we
+            // authenticated to.
+            if (!sameBytes(hostKey.blob(), result.hostKey().blob())) {
+                throw new SshException("the host key changed during a rekey");
+            }
+
+            WireWriter newKeys = new WireWriter(8);
+            newKeys.writeByte(Message.NEWKEYS);
+            transport.writePacket(newKeys.toByteArray());
+            transport.encryptOutgoing(new PacketCipher(
+                result.deriveKey('C', sessionId, PacketCipher.KEY_LENGTH)));
+
+            expect(transport.readMessage(), Message.NEWKEYS);
+            transport.decryptIncoming(new PacketCipher(
+                result.deriveKey('D', sessionId, PacketCipher.KEY_LENGTH)));
+        }
+    }
+
+    private static boolean sameBytes(byte[] a, byte[] b) {
+        if (a == null || b == null || a.length != b.length) {
+            return false;
+        }
+        for (int i = 0; i < a.length; i++) {
+            if (a[i] != b[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/ssh/src/berryssh/protocol/Transport.java
+++ b/ssh/src/berryssh/protocol/Transport.java
@@ -83,6 +83,8 @@ public final class Transport {
     private PacketCipher outgoing;
     private PacketCipher incoming;
 
+    private RekeyHandler rekeyHandler;
+
     private String clientVersion;
     private String serverVersion;
     private long sendSequence;
@@ -109,6 +111,33 @@ public final class Transport {
 
     public long receiveSequence() {
         return receiveSequence;
+    }
+
+    /**
+     * Runs a fresh key exchange when the server asks for one mid-session.
+     *
+     * Handled here for the same reason IGNORE and DEBUG are: a KEXINIT can
+     * arrive at any moment once the connection is up, and every state machine
+     * above this would otherwise have to know that.
+     */
+    public interface RekeyHandler {
+        void rekey(byte[] serverKexInit) throws IOException;
+    }
+
+    public void setRekeyHandler(RekeyHandler handler) {
+        this.rekeyHandler = handler;
+    }
+
+    /**
+     * The lock that serialises sending.
+     *
+     * Exposed so a rekey can hold it across the whole exchange. Between the two
+     * NEWKEYS the keys are changing, and a keystroke that slipped in would be
+     * encrypted under keys the server had already retired. Java monitors are
+     * reentrant, so writePacket still works for the thread holding it.
+     */
+    public Object sendLock() {
+        return sendLock;
     }
 
     /** Takes effect from the next packet we send. Call it straight after sending NEWKEYS. */
@@ -302,6 +331,13 @@ public final class Transport {
             }
             int type = payload[0] & 0xff;
             if (type == Message.IGNORE || type == Message.DEBUG) {
+                continue;
+            }
+            if (type == Message.KEXINIT && rekeyHandler != null) {
+                // OpenSSH asks for this after about a gigabyte or an hour.
+                // Before it was handled, an hour-old session died with a
+                // complaint about an unexpected message on a channel.
+                rekeyHandler.rekey(payload);
                 continue;
             }
             if (type == Message.DISCONNECT) {

--- a/ssh/src/berryssh/terminal/BitmapFont.java
+++ b/ssh/src/berryssh/terminal/BitmapFont.java
@@ -172,11 +172,11 @@ public final class BitmapFont {
         bgRed = (background >> 16) & 0xff;
         bgGreen = (background >> 8) & 0xff;
         bgBlue = background & 0xff;
-
-        // Everything cached was for the previous pair.
-        for (int i = 0; i < cachedFor.length; i++) {
-            cachedFor[i] = -1;
-        }
+        // Nothing is cleared here. cachedFor already records which pair each
+        // glyph was rendered for, so a stale entry is recoloured when it is
+        // next drawn — clearing would make a colour change cost the whole
+        // atlas instead of the handful of glyphs actually on screen, and a
+        // terminal UI changes colour many times per line.
     }
 
     /**

--- a/tools/rekey-server.sh
+++ b/tools/rekey-server.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# A throwaway SSH server that asks to rekey almost immediately.
+#
+# OpenSSH requests a rekey after about a gigabyte or an hour. Waiting an hour is
+# not a test, so this one is built with RekeyLimit at 64 KB, which makes a few
+# hundred kilobytes of output force ten of them.
+#
+# Deliberately separate from the `bbssh` container on port 2222: that one is
+# what the handset connects to, and restarting it to change its configuration
+# would interrupt whoever is using it.
+#
+#   tools/rekey-server.sh          # build and start on 2223
+#   tools/rekey-server.sh stop
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+NAME=berryssh-rekey
+IMAGE=berryssh-rekey-test
+PORT=2223
+
+export DOCKER_HOST="${DOCKER_HOST:-unix://$HOME/.orbstack/run/docker.sock}"
+DOCKER_CONFIG="$(mktemp -d)"; export DOCKER_CONFIG
+printf '{}' > "$DOCKER_CONFIG/config.json"
+trap 'rm -rf "$DOCKER_CONFIG"' EXIT
+
+if [ "${1:-start}" = "stop" ]; then
+    docker rm -f "$NAME" >/dev/null 2>&1 || true
+    echo "stopped"
+    exit 0
+fi
+
+build="$(mktemp -d)"
+cat > "$build/Dockerfile" <<'EOF'
+FROM bbssh-sshd:latest
+RUN printf '\nRekeyLimit 64K none\n' >> /etc/ssh/sshd_config.d/00-bbssh-legacy.conf \
+ && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" -q \
+ && printf '\nHostKey /etc/ssh/ssh_host_ed25519_key\n' >> /etc/ssh/sshd_config.d/00-bbssh-legacy.conf
+EOF
+
+echo "==> building $IMAGE"
+docker build -q -t "$IMAGE" "$build" >/dev/null
+rm -rf "$build"
+
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+docker run -d --rm --name "$NAME" -p "$PORT:22" "$IMAGE" >/dev/null
+sleep 2
+
+echo "==> $NAME on $PORT, $(docker exec "$NAME" sshd -T | grep -i '^rekeylimit')"
+echo "    spike2/against-server.sh now includes the rekey test"


### PR DESCRIPTION
Survive a rekey, and render colour and a cursor

Three things found by reading the code after the last device session rather
than by anything failing.

**A long session died on the rekey (#40)**

Nothing outside the initial handshake looked at KEXINIT. OpenSSH asks to rekey
after roughly a gigabyte or an hour, and when it did, the message reached the
channel and the session died with `unexpected KEXINIT on a session channel` —
an hour in, for no visible reason, blaming the channel for something the
transport should have handled.

It is handled at the transport now, for the same reason IGNORE and DEBUG are: a
KEXINIT can arrive at any moment once the connection is up, and every state
machine above should not have to know that.

Two details that are not optional. The session identifier stays fixed at the
first exchange hash — RFC 4253 requires it, and it is what the user
authentication signature was bound to, so replacing it would retroactively
invalidate the thing that proved who we are. And the send lock is held across
the whole exchange: between our NEWKEYS and the server's, the two directions
are on different keys, and a keystroke slipping out in the middle would be
encrypted under keys the server had already retired.

The first attempt registered the handler in the constructor, which made the
server's opening KEXINIT look like a rekey request and broke the initial
handshake outright. It is registered when the handshake finishes.

Verified against a server built with RekeyLimit at 64 KB, because waiting an
hour is not a test: 673 KB through a session that rekeyed ten times, with the
session identifier unchanged and the connection still working afterwards.
Without the handler the same test reproduces the original failure in seconds.
`tools/rekey-server.sh` builds it — deliberately not the shared container on
2222, which is what the handset connects to and should not be restarted.

**The terminal was monochrome and had no cursor (#41)**

`paint` set one colour pair for the whole screen and ignored the per-cell
attributes VT320 keeps in the high half of each cell, so `ls --color`, vim and
Claude CLI all rendered white on black. The eight ANSI colours are read now,
with bold and reverse, in the xterm values rather than pure primaries — pure
blue on black is close to unreadable and a terminal shows a lot of blue.

Nothing drew the cursor, so there was no indication of where typing would go.
It is drawn now, and deliberately not while the view is scrolled back, where it
would point at a line that is not the one being edited.

Colour changes no longer clear the glyph cache. `cachedFor` already records
which pair each glyph was rendered for, so a stale entry is recoloured when
next drawn; clearing made every colour change cost the whole atlas instead of
the few glyphs on screen, which for a terminal UI is many times per line.

Closes #40. Closes #41.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

