### PR TITLE
Authenticate with a key, and make the terminal size a choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ against vectors computed outside it. 49 in total.
 framing and §7.1 for algorithm negotiation, RFC 8731 §3 for the exchange hash
 and RFC 4253 §7.2 for key derivation, plus base64, host key parsing, the
 version exchange, the chacha20-poly1305 packet layer, UTF-8, host key trust,
-saved connections and the paths that have to reject malformed input. 106 in
-total. A further 39 cover the terminal: escape sequences, key dispatch,
+saved connections, OpenSSH private key files and the paths that have to
+reject malformed input. 112 in total. A further 39 cover the terminal: escape sequences, key dispatch,
 scrollback and the character-to-glyph mapping. They run under a Turkish default locale, which is the device's own and
 the setting most likely to break protocol code without raising an error
 anywhere.
@@ -154,7 +154,8 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] KEXINIT algorithm negotiation
 - [x] `curve25519-sha256` key exchange, host key check and key derivation
 - [x] `chacha20-poly1305@openssh.com` packet layer, and an encrypted handshake
-- [x] User authentication: `none`, `password`, `publickey` with Ed25519
+- [x] User authentication: `none`, `password`, `publickey` with Ed25519 —
+      confirmed against OpenSSH, which accepts a signature we made
 - [x] Channels, `pty-req`, shell — a working session against OpenSSH 9.2p1
 - [x] Host key trust, stored in RMS
 - [x] VT320 terminal emulation, and a bitmap font renderer

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")"
 
 NAME=berryssh
 VENDOR="berryssh"
-VERSION=0.3.1
+VERSION=0.4.0
 MIDLET_CLASS=berryssh.device.BerrysshMIDlet
 
 OUT=out

--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -59,6 +59,7 @@ public class ServerTests {
         rendersARealSessionThroughTheTerminal();
         survivesTypingWhileOutputArrives();
         survivesARekey();
+        authenticatesWithAKey();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -612,6 +613,64 @@ public class ServerTests {
 
             channel.write(Utf8.encode("exit\n"));
             channel.close();
+        } finally {
+            socket.close();
+        }
+    }
+
+    /**
+     * Public key authentication, end to end.
+     *
+     * The one part of the protocol that had never been confirmed: signing
+     * matches the RFC 8032 vectors and the server parses our request, but
+     * whether OpenSSH *accepts* the signature needs a key in an
+     * authorized_keys file. The throwaway server carries one — the RFC 8032
+     * test vector 3 seed, published in the RFC and used in this project's
+     * crypto vectors, which secures nothing.
+     */
+    private static void authenticatesWithAKey() throws Exception {
+        Socket socket;
+        try {
+            socket = new Socket(host, rekeyPort);
+        } catch (IOException e) {
+            System.out.println("  SKIP  publickey: nothing on " + host + ":" + rekeyPort
+                + " (tools/rekey-server.sh)");
+            return;
+        }
+        try {
+            socket.setSoTimeout(20000);
+            EntropyPool random = new EntropyPool();
+            random.seed();
+            Connection connection = new Connection(
+                socket.getInputStream(), socket.getOutputStream(), random);
+            connection.handshake();
+
+            UserAuth auth = new UserAuth(connection, user);
+            auth.begin();
+            auth.queryMethods();
+
+            byte[] seed = hex("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7");
+            checkTrue("OpenSSH accepts a signature we made", auth.publicKey(seed).succeeded());
+
+            // And a key the server has not been given must be refused, or the
+            // test above would prove only that the server accepts anything.
+            Socket second = new Socket(host, rekeyPort);
+            try {
+                second.setSoTimeout(20000);
+                EntropyPool r2 = new EntropyPool();
+                r2.seed();
+                Connection c2 = new Connection(
+                    second.getInputStream(), second.getOutputStream(), r2);
+                c2.handshake();
+                UserAuth a2 = new UserAuth(c2, user);
+                a2.begin();
+                a2.queryMethods();
+                byte[] other =
+                    hex("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+                checkTrue("an unauthorised key is refused", !a2.publicKey(other).succeeded());
+            } finally {
+                second.close();
+            }
         } finally {
             socket.close();
         }

--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -4,7 +4,9 @@ import berryssh.protocol.Base64;
 import berryssh.protocol.HostKey;
 import berryssh.protocol.KexInit;
 import berryssh.protocol.KeyExchange;
+import berryssh.crypto.Ed25519;
 import berryssh.protocol.KnownHosts;
+import berryssh.protocol.OpenSshKey;
 import berryssh.protocol.PacketCipher;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.SshException;
@@ -61,6 +63,7 @@ public class TransportTests {
         utf8Vectors();
         knownHostsPolicy();
         savedConnections();
+        opensshPrivateKeys();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -809,6 +812,96 @@ public class TransportTests {
         // read with its fields in the wrong order.
         checkRejected("a saved connection in an unknown format is refused",
             () -> Profile.decode(hex("0000009900000000")));
+    }
+
+    /**
+     * The OpenSSH private key file, which is how a key gets onto the handset.
+     *
+     * The container is built here from a published seed rather than a key file
+     * being committed: a repository is the wrong place for a private key even
+     * a worthless one, and building it means every byte of the format is
+     * stated rather than assumed. The parser was separately checked against a
+     * real `ssh-keygen -t ed25519` file, whose derived public key it reproduced
+     * exactly.
+     */
+    private static void opensshPrivateKeys() {
+        byte[] seed = hex("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7");
+        try {
+            String pem = opensshKey(seed, "none");
+            check("an OpenSSH key file yields its seed",
+                OpenSshKey.readEd25519Seed(pem), toHex(seed));
+
+            checkTrue("and the authorized_keys line derived from it is right",
+                OpenSshKey.authorizedKey(seed).indexOf(
+                    "AAAAC3NzaC1lZDI1NTE5AAAAIPxRzY5iGKGjjaR+0AIw8FgIFu0TujMDrF3rkRVIkIAl") > 0);
+
+            // Whitespace and line breaks vary with however it was pasted.
+            checkTrue("a key that lost its line breaks still reads",
+                sameBytes(seed, OpenSshKey.readEd25519Seed(collapse(pem))));
+        } catch (IOException e) {
+            fail("reading an OpenSSH key threw " + e);
+        }
+
+        checkRejected("something that is not a key file is refused",
+            () -> OpenSshKey.readEd25519Seed("hello"));
+        // An encrypted key has to say so. Failing with something about a bad
+        // key would send someone looking in the wrong place entirely.
+        checkRejected("an encrypted key is refused, by name",
+            () -> OpenSshKey.readEd25519Seed(opensshKey(seed, "aes256-ctr")));
+        checkRejected("a key whose halves disagree is refused",
+            () -> OpenSshKey.readEd25519Seed(corrupt(opensshKey(seed, "none"))));
+    }
+
+    /** Builds an openssh-key-v1 container around a seed. */
+    private static String opensshKey(byte[] seed, String cipher) {
+        byte[] publicKey = Ed25519.publicKey(seed);
+        byte[] secret = new byte[64];
+        System.arraycopy(seed, 0, secret, 0, 32);
+        System.arraycopy(publicKey, 0, secret, 32, 32);
+
+        WireWriter keyBlob = new WireWriter(64);
+        keyBlob.writeAsciiString("ssh-ed25519");
+        keyBlob.writeString(publicKey);
+
+        WireWriter section = new WireWriter(256);
+        section.writeUint32(0x01020304);
+        section.writeUint32(0x01020304);
+        section.writeAsciiString("ssh-ed25519");
+        section.writeString(publicKey);
+        section.writeString(secret);
+        section.writeAsciiString("test");
+
+        WireWriter w = new WireWriter(512);
+        w.writeRaw(Ascii.toBytes("openssh-key-v1"));
+        w.writeByte(0);
+        w.writeAsciiString(cipher);
+        w.writeAsciiString("none");
+        w.writeString(new byte[0]);
+        w.writeUint32(1);
+        w.writeString(keyBlob.toByteArray());
+        w.writeString(section.toByteArray());
+
+        return "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+            + Base64.encode(w.toByteArray())
+            + "\n-----END OPENSSH PRIVATE KEY-----\n";
+    }
+
+    private static String collapse(String pem) {
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < pem.length(); i++) {
+            char c = pem.charAt(i);
+            sb.append(c == '\n' ? ' ' : c);
+        }
+        return sb.toString();
+    }
+
+    /** Flips a bit inside the base64 body, leaving the markers intact. */
+    private static String corrupt(String pem) {
+        int begin = pem.indexOf("-----\n") + 6;
+        StringBuffer sb = new StringBuffer(pem);
+        char c = sb.charAt(begin + 200);
+        sb.setCharAt(begin + 200, c == 'A' ? 'B' : 'A');
+        return sb.toString();
     }
 
     private static byte[] slice(byte[] b, int offset, int length) {

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -24,6 +24,7 @@ import berryssh.protocol.Channel;
 import berryssh.protocol.Connection;
 import berryssh.protocol.HostKey;
 import berryssh.protocol.KnownHosts;
+import berryssh.protocol.OpenSshKey;
 import berryssh.protocol.UserAuth;
 import berryssh.protocol.Utf8;
 import berryssh.terminal.BitmapFont;
@@ -42,10 +43,6 @@ import berryssh.terminal.VT320;
  * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
  */
 public final class BerrysshMIDlet extends MIDlet implements CommandListener {
-
-    private static final String FONT = "/fonts/mono8x14.png";
-    private static final int CELL_WIDTH = 8;
-    private static final int CELL_HEIGHT = 14;
 
     private static final String NEW_CONNECTION = "New connection...";
 
@@ -95,6 +92,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private TextField userField;
     private TextField passwordField;
     private ChoiceGroup savePasswordChoice;
+    private ChoiceGroup fontChoice;
+    private TextField keyField;
     private String editingName;
 
     private TextField promptPassword;
@@ -314,6 +313,13 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         savePasswordChoice = new ChoiceGroup("", Choice.MULTIPLE,
             new String[] { "Save password (not encrypted)" }, null);
         savePasswordChoice.setSelectedIndex(0, profile != null && profile.savePassword());
+        // Pasted rather than typed: this is the contents of ~/.ssh/id_ed25519,
+        // which nobody is going to key in on a thumb keyboard.
+        keyField = new TextField("Private key (paste, optional)",
+            profile == null ? "" : profile.privateKey(), 2048, TextField.ANY);
+        fontChoice = new ChoiceGroup("Terminal size", Choice.EXCLUSIVE,
+            Profile.SIZE_LABELS, null);
+        fontChoice.setSelectedIndex(profile == null ? 0 : profile.fontSize(), true);
 
         editor.append(nameField);
         editor.append(hostField);
@@ -321,6 +327,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         editor.append(userField);
         editor.append(passwordField);
         editor.append(savePasswordChoice);
+        editor.append(keyField);
+        editor.append(fontChoice);
         editor.addCommand(save);
         editor.addCommand(back);
         editor.setCommandListener(this);
@@ -339,8 +347,23 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             name = host;
         }
 
+        // Checked here rather than at connect time: a key that will not parse
+        // should be rejected while the person who pasted it is still looking
+        // at it, not three screens later against a server.
+        String key = keyField.getString().trim();
+        if (key.length() > 0) {
+            try {
+                OpenSshKey.readEd25519Seed(key);
+            } catch (IOException e) {
+                show("That key cannot be read: " + e.getMessage(),
+                    AlertType.WARNING, editor);
+                return;
+            }
+        }
+
         Profile profile = new Profile(name, host, parsePort(portField.getString()),
-            user, passwordField.getString(), savePasswordChoice.isSelected(0));
+            user, passwordField.getString(), savePasswordChoice.isSelected(0),
+            key, fontChoice.getSelectedIndex());
         try {
             // Renaming replaces rather than duplicating.
             if (editingName != null && !editingName.equals(name)) {
@@ -357,7 +380,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
 
     /** Connects, asking for the password first when none was saved. */
     private void begin(Profile profile) {
-        if (profile.savePassword() && profile.password().length() > 0) {
+        if (profile.privateKey().length() > 0
+                || (profile.savePassword() && profile.password().length() > 0)) {
             start(profile);
             return;
         }
@@ -376,7 +400,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
 
         BitmapFont font;
         try {
-            font = BitmapFont.load(FONT, CELL_WIDTH, CELL_HEIGHT);
+            font = BitmapFont.load(profile.fontResource(),
+                profile.cellWidth(), profile.cellHeight());
         } catch (IOException e) {
             show("The font atlas is missing: " + e.getMessage(),
                 AlertType.ERROR, connections);
@@ -447,7 +472,21 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             UserAuth auth = new UserAuth(connection, profile.user());
             auth.begin();
             auth.queryMethods();
-            if (!auth.password(profile.password()).succeeded()) {
+
+            // The key first when there is one, and the password as a fallback:
+            // a key that the server has not been given is a failed attempt, not
+            // a reason to give up on a connection the user can still make.
+            boolean authenticated = false;
+            if (profile.privateKey().length() > 0) {
+                canvas.setStatus("authenticating with the key...");
+                authenticated = auth.publicKey(
+                    OpenSshKey.readEd25519Seed(profile.privateKey())).succeeded();
+            }
+            if (!authenticated && profile.password().length() > 0) {
+                canvas.setStatus("authenticating with the password...");
+                authenticated = auth.password(profile.password()).succeeded();
+            }
+            if (!authenticated) {
                 fail("Authentication failed.");
                 return;
             }

--- a/ssh/src/berryssh/device/Profile.java
+++ b/ssh/src/berryssh/device/Profile.java
@@ -30,7 +30,19 @@ public final class Profile {
         void delete(String name) throws IOException;
     }
 
-    private static final int FORMAT = 1;
+    /**
+     * Records written before the private key and font size existed say 1.
+     * Both are read, so adding fields does not throw away what is saved — a
+     * connection list that empties itself on upgrade is worse than the feature
+     * is worth.
+     */
+    private static final int FORMAT = 2;
+    private static final int FORMAT_WITHOUT_KEY = 1;
+
+    /** Cell sizes the atlases exist for, and what they give on a 480x360 screen. */
+    public static final int[] CELL_WIDTHS = { 8, 6, 6 };
+    public static final int[] CELL_HEIGHTS = { 14, 11, 9 };
+    public static final String[] SIZE_LABELS = { "8x14 (60 cols)", "6x11 (80 cols)", "6x9 (80 cols)" };
 
     private final String name;
     private final String host;
@@ -38,15 +50,24 @@ public final class Profile {
     private final String user;
     private final String password;
     private final boolean savePassword;
+    private final String privateKey;
+    private final int fontSize;
 
     public Profile(String name, String host, int port, String user,
                    String password, boolean savePassword) {
+        this(name, host, port, user, password, savePassword, "", 0);
+    }
+
+    public Profile(String name, String host, int port, String user, String password,
+                   boolean savePassword, String privateKey, int fontSize) {
         this.name = name;
         this.host = host;
         this.port = port;
         this.user = user;
         this.password = password == null ? "" : password;
         this.savePassword = savePassword;
+        this.privateKey = privateKey == null ? "" : privateKey;
+        this.fontSize = (fontSize < 0 || fontSize >= CELL_WIDTHS.length) ? 0 : fontSize;
     }
 
     public String name() {
@@ -74,6 +95,28 @@ public final class Profile {
         return savePassword;
     }
 
+    /** An OpenSSH private key, as pasted, or empty. */
+    public String privateKey() {
+        return privateKey;
+    }
+
+    /** An index into {@link #CELL_WIDTHS}. */
+    public int fontSize() {
+        return fontSize;
+    }
+
+    public int cellWidth() {
+        return CELL_WIDTHS[fontSize];
+    }
+
+    public int cellHeight() {
+        return CELL_HEIGHTS[fontSize];
+    }
+
+    public String fontResource() {
+        return "/fonts/mono" + cellWidth() + "x" + cellHeight() + ".png";
+    }
+
     /** What the connection list shows: enough to tell two servers apart. */
     public String label() {
         String where = user + "@" + host;
@@ -99,17 +142,19 @@ public final class Profile {
         w.writeString(Utf8.encode(user));
         w.writeBoolean(savePassword);
         w.writeString(Utf8.encode(savePassword ? password : ""));
+        w.writeString(Utf8.encode(privateKey));
+        w.writeUint32(fontSize);
         return w.toByteArray();
     }
 
     public static Profile decode(byte[] record) throws IOException {
         WireReader r = new WireReader(record);
         long format = r.readUint32();
-        if (format != FORMAT) {
-            // A record written by a version that is not this one. Refusing it
-            // is better than reading its fields in the wrong order.
+        if (format != FORMAT && format != FORMAT_WITHOUT_KEY) {
+            // A record from a version that is not one of ours. Refusing it is
+            // better than reading its fields in the wrong order.
             throw new SshException("saved connection is in format " + format
-                + ", not " + FORMAT);
+                + ", not " + FORMAT_WITHOUT_KEY + " or " + FORMAT);
         }
         String name = Utf8.decode(r.readString());
         String host = Utf8.decode(r.readString());
@@ -117,6 +162,14 @@ public final class Profile {
         String user = Utf8.decode(r.readString());
         boolean savePassword = r.readBoolean();
         String password = Utf8.decode(r.readString());
-        return new Profile(name, host, port, user, password, savePassword);
+
+        String privateKey = "";
+        int fontSize = 0;
+        if (format == FORMAT) {
+            privateKey = Utf8.decode(r.readString());
+            fontSize = (int) r.readUint32();
+        }
+        return new Profile(name, host, port, user, password, savePassword,
+            privateKey, fontSize);
     }
 }

--- a/ssh/src/berryssh/protocol/OpenSshKey.java
+++ b/ssh/src/berryssh/protocol/OpenSshKey.java
@@ -1,0 +1,119 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+
+import berryssh.crypto.Ed25519;
+
+/**
+ * Reads the private key file OpenSSH writes.
+ *
+ * The realistic way to get a key onto the handset is to paste the contents of
+ * `~/.ssh/id_ed25519`, so that is what this understands: the `openssh-key-v1`
+ * container, base64 inside PEM markers.
+ *
+ * Only unencrypted keys. A passphrase-protected one needs bcrypt-pbkdf and AES,
+ * neither of which exists here and neither of which is worth adding for this —
+ * `ssh-keygen -p` removes a passphrase, and a key file copied onto a phone is
+ * already only as safe as the phone. What matters is that it says so rather
+ * than failing with something about a bad key.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class OpenSshKey {
+
+    private static final String BEGIN = "-----BEGIN OPENSSH PRIVATE KEY-----";
+    private static final String END = "-----END OPENSSH PRIVATE KEY-----";
+
+    private static final String MAGIC = "openssh-key-v1";
+
+    private OpenSshKey() {
+    }
+
+    /**
+     * Extracts the 32-byte Ed25519 seed.
+     *
+     * OpenSSH stores 64 bytes: the seed followed by the public key it derives
+     * to. Only the first half is the secret; the second is checked against the
+     * key's own public field, which catches a truncated or mangled paste
+     * before it turns into a signature nobody can verify.
+     */
+    public static byte[] readEd25519Seed(String pem) throws IOException {
+        int begin = pem.indexOf(BEGIN);
+        int end = pem.indexOf(END);
+        if (begin < 0 || end < 0 || end < begin) {
+            throw new SshException("not an OpenSSH private key");
+        }
+        byte[] blob = Base64.decode(pem.substring(begin + BEGIN.length(), end));
+
+        byte[] magic = Ascii.toBytes(MAGIC);
+        if (blob.length < magic.length + 1) {
+            throw new SshException("the key file is too short to be one");
+        }
+        for (int i = 0; i < magic.length; i++) {
+            if (blob[i] != magic[i]) {
+                throw new SshException("not an openssh-key-v1 file");
+            }
+        }
+
+        WireReader r = new WireReader(blob, magic.length + 1, blob.length - magic.length - 1);
+        String cipher = r.readAsciiString();
+        r.readAsciiString();                    // kdf name
+        r.readString();                         // kdf options
+        if (!"none".equals(cipher)) {
+            throw new SshException("the key is encrypted with " + cipher
+                + "; remove the passphrase with `ssh-keygen -p` first");
+        }
+
+        long keys = r.readUint32();
+        if (keys != 1) {
+            throw new SshException("the file holds " + keys + " keys, not one");
+        }
+        r.readString();                         // the public key, repeated below
+
+        byte[] section = r.readString();
+        WireReader p = new WireReader(section);
+        long check1 = p.readUint32();
+        long check2 = p.readUint32();
+        if (check1 != check2) {
+            // With no passphrase these are equal by construction; unequal means
+            // the file is damaged, or encrypted in a way we did not detect.
+            throw new SshException("the key file did not decode cleanly");
+        }
+
+        String type = p.readAsciiString();
+        if (!HostKey.ALGORITHM.equals(type)) {
+            throw new SshException("the key is " + type + ", and only "
+                + HostKey.ALGORITHM + " is supported");
+        }
+
+        byte[] publicKey = p.readString();
+        byte[] secret = p.readString();
+        if (publicKey.length != Ed25519.PUBLIC_KEY_LENGTH
+                || secret.length != Ed25519.SEED_LENGTH + Ed25519.PUBLIC_KEY_LENGTH) {
+            throw new SshException("the key is not the right size for ssh-ed25519");
+        }
+
+        byte[] seed = new byte[Ed25519.SEED_LENGTH];
+        System.arraycopy(secret, 0, seed, 0, Ed25519.SEED_LENGTH);
+
+        // The stored public half, the repeated one, and the one the seed
+        // actually derives to all have to agree. A paste that lost a line
+        // decodes to something plausible otherwise, and the failure would
+        // surface much later as a signature the server rejects.
+        byte[] derived = Ed25519.publicKey(seed);
+        for (int i = 0; i < Ed25519.PUBLIC_KEY_LENGTH; i++) {
+            if (publicKey[i] != secret[Ed25519.SEED_LENGTH + i] || publicKey[i] != derived[i]) {
+                throw new SshException("the key's public and private halves disagree");
+            }
+        }
+        return seed;
+    }
+
+    /** The `ssh-ed25519 AAAA...` line to put in an authorized_keys file. */
+    public static String authorizedKey(byte[] seed) {
+        WireWriter w = new WireWriter(64);
+        w.writeAsciiString(HostKey.ALGORITHM);
+        w.writeString(Ed25519.publicKey(seed));
+        return HostKey.ALGORITHM + " " + Base64.encode(w.toByteArray());
+    }
+}

--- a/tools/rekey-server.sh
+++ b/tools/rekey-server.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
-# A throwaway SSH server that asks to rekey almost immediately.
+# A throwaway SSH server for the tests that need the server configured.
 #
-# OpenSSH requests a rekey after about a gigabyte or an hour. Waiting an hour is
-# not a test, so this one is built with RekeyLimit at 64 KB, which makes a few
-# hundred kilobytes of output force ten of them.
+# Two things the shared container cannot provide. It rekeys every 64 KB, so the
+# rekey path can be exercised in seconds rather than the hour OpenSSH would
+# otherwise take. And it authorises a known test key, so public key
+# authentication can be confirmed end to end.
 #
 # Deliberately separate from the `bbssh` container on port 2222: that one is
-# what the handset connects to, and restarting it to change its configuration
-# would interrupt whoever is using it.
+# what the handset connects to, and reconfiguring or restarting it would
+# interrupt whoever is using it.
+#
+# The authorised key is the RFC 8032 test vector 3 seed, which is published in
+# the RFC and used in this project's crypto vectors. It is a test value in the
+# most literal sense and secures nothing.
 #
 #   tools/rekey-server.sh          # build and start on 2223
 #   tools/rekey-server.sh stop
@@ -31,11 +36,18 @@ if [ "${1:-start}" = "stop" ]; then
 fi
 
 build="$(mktemp -d)"
-cat > "$build/Dockerfile" <<'EOF'
+# Public half of the RFC 8032 test vector 3 seed.
+AUTHORIZED="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPxRzY5iGKGjjaR+0AIw8FgIFu0TujMDrF3rkRVIkIAl berryssh-test-vector"
+
+cat > "$build/Dockerfile" <<EOF
 FROM bbssh-sshd:latest
-RUN printf '\nRekeyLimit 64K none\n' >> /etc/ssh/sshd_config.d/00-bbssh-legacy.conf \
- && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" -q \
- && printf '\nHostKey /etc/ssh/ssh_host_ed25519_key\n' >> /etc/ssh/sshd_config.d/00-bbssh-legacy.conf
+RUN printf '\nRekeyLimit 64K none\n' >> /etc/ssh/sshd_config.d/00-bbssh-legacy.conf \\
+ && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" -q \\
+ && printf '\nHostKey /etc/ssh/ssh_host_ed25519_key\n' >> /etc/ssh/sshd_config.d/00-bbssh-legacy.conf \\
+ && mkdir -p /home/bb/.ssh \\
+ && echo '$AUTHORIZED' > /home/bb/.ssh/authorized_keys \\
+ && chown -R bb:bb /home/bb/.ssh \\
+ && chmod 700 /home/bb/.ssh && chmod 600 /home/bb/.ssh/authorized_keys
 EOF
 
 echo "==> building $IMAGE"


### PR DESCRIPTION
Authenticate with a key, and make the terminal size a choice

**Public key authentication now works, and is proved to (#42)**

The protocol side has been in place since #7 and the signing has matched the
RFC 8032 vectors throughout, but nothing could reach it: there was no way to
get a key onto the device. `OpenSshKey` reads the `openssh-key-v1` file OpenSSH
writes, so what goes in the field is the contents of `~/.ssh/id_ed25519` —
pasted, because nobody is going to key that in on a thumb keyboard.

It checks the key's stored public half against the repeated one *and* against
what the seed actually derives to. A paste that lost a line still decodes to
something plausible, and without that check the failure would surface much
later as a signature the server rejects, which is a long way from the cause.
Encrypted keys are refused by name, pointing at `ssh-keygen -p`, rather than
failing with something about a bad key.

Verified two ways. Against a real `ssh-keygen -t ed25519` file, whose public
key the parser reproduced exactly. And end to end against a server that
authorises a known key: **OpenSSH accepts a signature we made** — the last part
of the protocol that had never been confirmed. An unauthorised key is refused
in the same run, so the positive result is not just a server that accepts
anything.

The authorised key is the RFC 8032 test vector 3 seed, published in the RFC and
already in this project's crypto vectors. It lives on the throwaway server from
`tools/rekey-server.sh`, not on the shared container: that one is what the
handset connects to, and its configuration is not this project's to change.

The key is tried before the password and the password is still tried after. A
key the server has not been given is a failed attempt, not a reason to abandon
a connection the user can still make.

**The terminal size is a choice (#43)**

Three atlases shipped and only 8x14 could be reached. 6x11 and 6x9 both give 80
columns on this screen, which is what a great deal of terminal output assumes.
It is per connection and saved with it.

**Saved connections survive the change**

Both features add fields, so the record format moves to 2 — and 1 is still
read, with the new fields defaulted. A connection list that empties itself on
upgrade would cost more than either feature is worth.

Closes #42. Closes #43.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

