### PR TITLE
Draw the connection screens instead of leaving them to MIDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] A MIDlet that connects, authenticates and runs a shell
 - [x] Runs on a Bold 9790: connects, authenticates, opens a shell
 - [x] Saved connections, host key confirmation, and a transport two threads can share
+- [x] Screens drawn rather than left to MIDP's own forms
 - [ ] Keyboard mapping confirmed against the hardware's real key codes
 
 ## Prior art

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")"
 
 NAME=berryssh
 VENDOR="berryssh"
-VERSION=0.4.0
+VERSION=0.5.0
 MIDLET_CLASS=berryssh.device.BerrysshMIDlet
 
 OUT=out

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -8,14 +8,12 @@ import javax.microedition.io.Connector;
 import javax.microedition.io.SocketConnection;
 import javax.microedition.lcdui.Alert;
 import javax.microedition.lcdui.AlertType;
-import javax.microedition.lcdui.Choice;
-import javax.microedition.lcdui.ChoiceGroup;
 import javax.microedition.lcdui.Command;
 import javax.microedition.lcdui.CommandListener;
 import javax.microedition.lcdui.Display;
 import javax.microedition.lcdui.Displayable;
 import javax.microedition.lcdui.Form;
-import javax.microedition.lcdui.List;
+import javax.microedition.lcdui.TextBox;
 import javax.microedition.lcdui.TextField;
 import javax.microedition.midlet.MIDlet;
 
@@ -62,6 +60,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
 
     // The editor
     private final Command save = new Command("Save", Command.OK, 1);
+    private final Command accept = new Command("OK", Command.OK, 1);
     private final Command back = new Command("Back", Command.BACK, 2);
 
     // The password prompt
@@ -81,22 +80,28 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private final Command reconnect = new Command("Reconnect", Command.SCREEN, 7);
     private final Command disconnect = new Command("Disconnect", Command.STOP, 8);
 
+    private static final String[] FIELDS = {
+        "Name", "Host", "Port", "User", "Password", "Save password",
+        "Private key", "Terminal size"
+    };
+
     private Display display;
-    private List connections;
+    private ListScreen connections;
     private Profile[] profiles = new Profile[0];
 
-    private Form editor;
-    private TextField nameField;
-    private TextField hostField;
-    private TextField portField;
-    private TextField userField;
-    private TextField passwordField;
-    private ChoiceGroup savePasswordChoice;
-    private ChoiceGroup fontChoice;
-    private TextField keyField;
+    private ListScreen editor;
     private String editingName;
+    private String editName = "";
+    private String editHost = "";
+    private String editPort = "22";
+    private String editUser = "";
+    private String editPassword = "";
+    private boolean editSavePassword;
+    private String editKey = "";
+    private int editFontSize;
+    private int editingField = -1;
 
-    private TextField promptPassword;
+    private TextBox entry;
     private Profile pendingProfile;
 
     private TerminalCanvas canvas;
@@ -136,7 +141,12 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             }
         }).start();
 
-        connections = new List("berryssh", Choice.IMPLICIT);
+        connections = new ListScreen("berryssh", new ListScreen.Listener() {
+            public void selected(int index) {
+                open(index);
+            }
+        });
+        connections.setHint("Menu for New, Edit, Delete");
         connections.addCommand(connect);
         connections.addCommand(newConnection);
         connections.addCommand(edit);
@@ -160,16 +170,30 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         } catch (IOException e) {
             profiles = new Profile[0];
         }
-        connections.deleteAll();
+        String[] names = new String[profiles.length + 1];
+        String[] details = new String[profiles.length + 1];
         for (int i = 0; i < profiles.length; i++) {
-            connections.append(profiles[i].label(), null);
+            names[i] = profiles[i].name();
+            details[i] = profiles[i].user() + "@" + profiles[i].host()
+                + (profiles[i].port() == 22 ? "" : ":" + profiles[i].port());
         }
-        connections.append(NEW_CONNECTION, null);
+        names[profiles.length] = NEW_CONNECTION;
+        details[profiles.length] = "add a server";
+        connections.setRows(names, details);
+    }
+
+    /** A row of the connection list was chosen. */
+    private void open(int index) {
+        if (index >= profiles.length) {
+            showEditor(null);
+        } else {
+            begin(profiles[index]);
+        }
     }
 
     /** The profile the list is pointing at, or null for the New entry. */
     private Profile selected() {
-        int index = connections.getSelectedIndex();
+        int index = connections.selectedIndex();
         if (index < 0 || index >= profiles.length) {
             return null;
         }
@@ -184,13 +208,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         }
 
         if (from == connections) {
-            if (command == List.SELECT_COMMAND || command == connect) {
-                Profile profile = selected();
-                if (profile == null) {
-                    showEditor(null);
-                } else {
-                    begin(profile);
-                }
+            if (command == connect) {
+                open(connections.selectedIndex());
                 return;
             }
             if (command == newConnection) {
@@ -216,11 +235,22 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             }
         }
 
+        if (command == accept) {
+            acceptField();
+            return;
+        }
         if (command == save) {
             saveEditor();
             return;
         }
         if (command == back) {
+            // Out of a field goes back to the editor; out of anything else
+            // goes back to the list.
+            if (editingField >= 0) {
+                editingField = -1;
+                display.setCurrent(editor);
+                return;
+            }
             pendingProfile = null;
             refreshConnections();
             display.setCurrent(connections);
@@ -231,7 +261,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             pendingProfile = null;
             if (p != null) {
                 start(new Profile(p.name(), p.host(), p.port(), p.user(),
-                    promptPassword.getString(), false));
+                    entry.getString(), false, p.privateKey(), p.fontSize()));
             }
             return;
         }
@@ -294,66 +324,124 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
 
     private void showEditor(Profile profile) {
         editingName = profile == null ? null : profile.name();
-        editor = new Form(profile == null ? "New connection" : "Edit connection");
+        editName = profile == null ? "" : profile.name();
+        editHost = profile == null ? "" : profile.host();
+        editPort = profile == null ? "22" : "" + profile.port();
+        editUser = profile == null ? "" : profile.user();
+        editPassword = profile == null ? "" : profile.password();
+        editSavePassword = profile != null && profile.savePassword();
+        editKey = profile == null ? "" : profile.privateKey();
+        editFontSize = profile == null ? 0 : profile.fontSize();
 
-        nameField = new TextField("Name", profile == null ? "" : profile.name(),
-            32, TextField.ANY);
-        // URL and EMAILADDR put the device into an input mode that does not
-        // capitalise the first letter. TextField.ANY does, which made every
-        // host and user name start with a capital and need correcting by hand
-        // on a keyboard where that is several presses.
-        hostField = new TextField("Host", profile == null ? "" : profile.host(),
-            64, TextField.URL | TextField.NON_PREDICTIVE);
-        portField = new TextField("Port", profile == null ? "22" : "" + profile.port(),
-            5, TextField.NUMERIC);
-        userField = new TextField("User", profile == null ? "" : profile.user(),
-            32, TextField.EMAILADDR | TextField.NON_PREDICTIVE);
-        passwordField = new TextField("Password",
-            profile == null ? "" : profile.password(), 64, TextField.PASSWORD);
-        savePasswordChoice = new ChoiceGroup("", Choice.MULTIPLE,
-            new String[] { "Save password (not encrypted)" }, null);
-        savePasswordChoice.setSelectedIndex(0, profile != null && profile.savePassword());
-        // Pasted rather than typed: this is the contents of ~/.ssh/id_ed25519,
-        // which nobody is going to key in on a thumb keyboard.
-        keyField = new TextField("Private key (paste, optional)",
-            profile == null ? "" : profile.privateKey(), 2048, TextField.ANY);
-        fontChoice = new ChoiceGroup("Terminal size", Choice.EXCLUSIVE,
-            Profile.SIZE_LABELS, null);
-        fontChoice.setSelectedIndex(profile == null ? 0 : profile.fontSize(), true);
+        if (editor == null) {
+            editor = new ListScreen("Connection", new ListScreen.Listener() {
+                public void selected(int index) {
+                    editField(index);
+                }
+            });
+            editor.setHint("Menu to save or go back");
+            editor.addCommand(save);
+            editor.addCommand(back);
+            editor.addCommand(quit);
+            editor.setCommandListener(this);
+        }
+        refreshEditor();
+        display.setCurrent(editor);
+    }
 
-        editor.append(nameField);
-        editor.append(hostField);
-        editor.append(portField);
-        editor.append(userField);
-        editor.append(passwordField);
-        editor.append(savePasswordChoice);
-        editor.append(keyField);
-        editor.append(fontChoice);
-        editor.addCommand(save);
-        editor.addCommand(back);
-        editor.setCommandListener(this);
+    private void refreshEditor() {
+        String[] values = {
+            editName,
+            editHost,
+            editPort,
+            editUser,
+            // Never the password itself, even hidden behind asterisks whose
+            // count would give away its length.
+            editPassword.length() > 0 ? "set" : "not set",
+            editSavePassword ? "yes  (stored unencrypted)" : "no",
+            editKey.length() > 0 ? "set" : "not set  (paste id_ed25519)",
+            Profile.SIZE_LABELS[editFontSize]
+        };
+        String[] names = new String[FIELDS.length];
+        for (int i = 0; i < FIELDS.length; i++) {
+            names[i] = FIELDS[i];
+        }
+        editor.setRows(names, values);
+    }
+
+    /**
+     * Opens a field.
+     *
+     * The two that are a choice rather than a value just change; the rest hand
+     * over to TextBox, which is the platform's own full-screen editor. It knows
+     * this keyboard, its input modes and its capitalisation rules, and
+     * reimplementing that on a canvas would be worse in every way that matters.
+     */
+    private void editField(int index) {
+        if (index == 5) {
+            editSavePassword = !editSavePassword;
+            refreshEditor();
+            return;
+        }
+        if (index == 7) {
+            editFontSize = (editFontSize + 1) % Profile.SIZE_LABELS.length;
+            refreshEditor();
+            return;
+        }
+
+        editingField = index;
+        String value;
+        int size;
+        int constraints;
+        switch (index) {
+            case 0: value = editName; size = 32; constraints = TextField.ANY; break;
+            // URL and EMAILADDR put the device into an input mode that does not
+            // capitalise the first letter. ANY does, which made every host and
+            // user name need correcting by hand.
+            case 1: value = editHost; size = 64;
+                    constraints = TextField.URL | TextField.NON_PREDICTIVE; break;
+            case 2: value = editPort; size = 5; constraints = TextField.NUMERIC; break;
+            case 3: value = editUser; size = 32;
+                    constraints = TextField.EMAILADDR | TextField.NON_PREDICTIVE; break;
+            case 4: value = editPassword; size = 64; constraints = TextField.PASSWORD; break;
+            default: value = editKey; size = 2048; constraints = TextField.ANY; break;
+        }
+
+        entry = new TextBox(FIELDS[index], value, size, constraints);
+        entry.addCommand(accept);
+        entry.addCommand(back);
+        entry.setCommandListener(this);
+        display.setCurrent(entry);
+    }
+
+    private void acceptField() {
+        String value = entry.getString();
+        switch (editingField) {
+            case 0: editName = value.trim(); break;
+            case 1: editHost = value.trim(); break;
+            case 2: editPort = value.trim(); break;
+            case 3: editUser = value.trim(); break;
+            case 4: editPassword = value; break;
+            default: editKey = value.trim(); break;
+        }
+        editingField = -1;
+        refreshEditor();
         display.setCurrent(editor);
     }
 
     private void saveEditor() {
-        String host = hostField.getString().trim();
-        String user = userField.getString().trim();
-        if (host.length() == 0 || user.length() == 0) {
+        if (editHost.length() == 0 || editUser.length() == 0) {
             show("A host and a user are needed.", AlertType.WARNING, editor);
             return;
         }
-        String name = nameField.getString().trim();
-        if (name.length() == 0) {
-            name = host;
-        }
+        String name = editName.length() == 0 ? editHost : editName;
 
         // Checked here rather than at connect time: a key that will not parse
-        // should be rejected while the person who pasted it is still looking
-        // at it, not three screens later against a server.
-        String key = keyField.getString().trim();
-        if (key.length() > 0) {
+        // should be rejected while the person who pasted it is still looking at
+        // it, not three screens later against a server.
+        if (editKey.length() > 0) {
             try {
-                OpenSshKey.readEd25519Seed(key);
+                OpenSshKey.readEd25519Seed(editKey);
             } catch (IOException e) {
                 show("That key cannot be read: " + e.getMessage(),
                     AlertType.WARNING, editor);
@@ -361,9 +449,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             }
         }
 
-        Profile profile = new Profile(name, host, parsePort(portField.getString()),
-            user, passwordField.getString(), savePasswordChoice.isSelected(0),
-            key, fontChoice.getSelectedIndex());
+        Profile profile = new Profile(name, editHost, parsePort(editPort), editUser,
+            editPassword, editSavePassword, editKey, editFontSize);
         try {
             // Renaming replaces rather than duplicating.
             if (editingName != null && !editingName.equals(name)) {
@@ -386,13 +473,12 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             return;
         }
         pendingProfile = profile;
-        Form prompt = new Form(profile.user() + "@" + profile.host());
-        promptPassword = new TextField("Password", "", 64, TextField.PASSWORD);
-        prompt.append(promptPassword);
-        prompt.addCommand(go);
-        prompt.addCommand(back);
-        prompt.setCommandListener(this);
-        display.setCurrent(prompt);
+        entry = new TextBox(profile.user() + "@" + profile.host(), "", 64,
+            TextField.PASSWORD);
+        entry.addCommand(go);
+        entry.addCommand(back);
+        entry.setCommandListener(this);
+        display.setCurrent(entry);
     }
 
     private void start(final Profile profile) {

--- a/ssh/src/berryssh/device/Chrome.java
+++ b/ssh/src/berryssh/device/Chrome.java
@@ -1,0 +1,128 @@
+package berryssh.device;
+
+import javax.microedition.lcdui.Font;
+import javax.microedition.lcdui.Graphics;
+
+/**
+ * The palette and the furniture the drawn screens share.
+ *
+ * MIDP's own Form and List are drawn by the device, which means a white 2003
+ * feature-phone menu in front of a terminal that looks nothing like it. A
+ * Canvas gives every pixel, which is how the terminal is already drawn.
+ *
+ * Text is left to MIDP's Font rather than the terminal's bitmap atlas. The
+ * atlas is monospace at eight pixels wide, which is right for a terminal grid
+ * and wrong for a label; the system font is proportional and is rendered by
+ * the device at whatever quality it manages natively.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Chrome {
+
+    public static final int BACKGROUND = 0x0d0d10;
+    public static final int BAR = 0x1b1b22;
+    public static final int ROW = 0x16161c;
+    public static final int SELECTED = 0x1f4d7a;
+    public static final int ACCENT = 0x4a90d9;
+    public static final int TEXT = 0xe8e8ea;
+    public static final int MUTED = 0x8a8a92;
+    public static final int RULE = 0x2a2a33;
+
+    public static final int PADDING = 6;
+
+    private Chrome() {
+    }
+
+    public static Font title() {
+        return Font.getFont(Font.FACE_PROPORTIONAL, Font.STYLE_BOLD, Font.SIZE_SMALL);
+    }
+
+    public static Font label() {
+        return Font.getFont(Font.FACE_PROPORTIONAL, Font.STYLE_BOLD, Font.SIZE_SMALL);
+    }
+
+    public static Font detail() {
+        return Font.getFont(Font.FACE_PROPORTIONAL, Font.STYLE_PLAIN, Font.SIZE_SMALL);
+    }
+
+    /** Height of a two-line row: a name and what it reaches. */
+    public static int rowHeight() {
+        return label().getHeight() + detail().getHeight() + PADDING;
+    }
+
+    public static int barHeight() {
+        return title().getHeight() + PADDING * 2;
+    }
+
+    /** Draws the top bar and returns the y the content starts at. */
+    public static int drawTitleBar(Graphics g, int width, String text) {
+        int height = barHeight();
+        g.setColor(BAR);
+        g.fillRect(0, 0, width, height);
+        g.setColor(ACCENT);
+        g.fillRect(0, height - 2, width, 2);
+        g.setColor(TEXT);
+        g.setFont(title());
+        g.drawString(text, PADDING, PADDING, Graphics.TOP | Graphics.LEFT);
+        return height;
+    }
+
+    /** Draws the hint line at the foot and returns the y it starts at. */
+    public static int drawFooter(Graphics g, int width, int height, String hint) {
+        Font font = detail();
+        int top = height - font.getHeight() - PADDING;
+        g.setColor(BAR);
+        g.fillRect(0, top, width, height - top);
+        g.setColor(RULE);
+        g.drawLine(0, top, width, top);
+        g.setColor(MUTED);
+        g.setFont(font);
+        g.drawString(hint, PADDING, top + PADDING / 2, Graphics.TOP | Graphics.LEFT);
+        return top;
+    }
+
+    /**
+     * Draws one row.
+     *
+     * The detail line is clipped rather than wrapped: a hostname long enough to
+     * wrap would push every row below it out of place, and a list whose rows
+     * move as the contents change is harder to use than one that truncates.
+     */
+    public static void drawRow(Graphics g, int width, int y, String name, String detail,
+                               boolean selected) {
+        int height = rowHeight();
+        g.setColor(selected ? SELECTED : ROW);
+        g.fillRect(0, y, width, height - 1);
+        if (selected) {
+            g.setColor(ACCENT);
+            g.fillRect(0, y, 3, height - 1);
+        }
+
+        g.setColor(TEXT);
+        g.setFont(label());
+        g.drawString(clip(name, label(), width - PADDING * 2),
+            PADDING + 4, y + PADDING / 2, Graphics.TOP | Graphics.LEFT);
+
+        if (detail != null && detail.length() > 0) {
+            g.setColor(selected ? TEXT : MUTED);
+            g.setFont(detail());
+            g.drawString(clip(detail, detail(), width - PADDING * 2),
+                PADDING + 4, y + PADDING / 2 + label().getHeight(),
+                Graphics.TOP | Graphics.LEFT);
+        }
+    }
+
+    /** Trims a string to fit, with an ellipsis, measuring as it goes. */
+    public static String clip(String text, Font font, int width) {
+        if (font.stringWidth(text) <= width) {
+            return text;
+        }
+        for (int i = text.length() - 1; i > 0; i--) {
+            String candidate = text.substring(0, i) + "...";
+            if (font.stringWidth(candidate) <= width) {
+                return candidate;
+            }
+        }
+        return "";
+    }
+}

--- a/ssh/src/berryssh/device/ListScreen.java
+++ b/ssh/src/berryssh/device/ListScreen.java
@@ -1,0 +1,151 @@
+package berryssh.device;
+
+import javax.microedition.lcdui.Canvas;
+import javax.microedition.lcdui.Graphics;
+
+/**
+ * A drawn list of rows.
+ *
+ * Used for the connection list and for the editor's fields, because they are
+ * the same shape: a title, rows of a name over a detail, one of them selected,
+ * and a hint at the foot.
+ *
+ * Every command the owner adds stays in the menu. The drawing here cannot be
+ * verified without the hardware, and a screen that draws wrongly must still be
+ * one the user can act on and leave — which is the trap full-screen mode set
+ * earlier, when the menu vanished along with the way out.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class ListScreen extends Canvas {
+
+    /** What the owner does when a row is chosen. */
+    public interface Listener {
+        void selected(int index);
+    }
+
+    private final String title;
+    private final Listener listener;
+
+    private String[] names = new String[0];
+    private String[] details = new String[0];
+    private String hint = "";
+    private int selected;
+    private int scroll;
+
+    public ListScreen(String title, Listener listener) {
+        this.title = title;
+        this.listener = listener;
+        setFullScreenMode(false);
+    }
+
+    public void setRows(String[] names, String[] details) {
+        this.names = names;
+        this.details = details;
+        if (selected >= names.length) {
+            selected = names.length == 0 ? 0 : names.length - 1;
+        }
+        repaint();
+    }
+
+    public void setHint(String hint) {
+        this.hint = hint == null ? "" : hint;
+        repaint();
+    }
+
+    public int selectedIndex() {
+        return selected;
+    }
+
+    public void select(int index) {
+        if (index >= 0 && index < names.length) {
+            selected = index;
+            repaint();
+        }
+    }
+
+    protected void paint(Graphics g) {
+        int width = getWidth();
+        int height = getHeight();
+
+        g.setColor(Chrome.BACKGROUND);
+        g.fillRect(0, 0, width, height);
+
+        int top = Chrome.drawTitleBar(g, width, title);
+        int bottom = hint.length() > 0
+            ? Chrome.drawFooter(g, width, height, hint)
+            : height;
+
+        int rowHeight = Chrome.rowHeight();
+        int visible = (bottom - top) / rowHeight;
+        if (visible < 1) {
+            visible = 1;
+        }
+        // Keep the selection on screen without moving the list more than it
+        // has to: a list that recentres on every keypress is disorienting.
+        if (selected < scroll) {
+            scroll = selected;
+        }
+        if (selected >= scroll + visible) {
+            scroll = selected - visible + 1;
+        }
+        if (scroll > names.length - visible) {
+            scroll = names.length - visible;
+        }
+        if (scroll < 0) {
+            scroll = 0;
+        }
+
+        g.setClip(0, top, width, bottom - top);
+        for (int i = 0; i < visible && scroll + i < names.length; i++) {
+            int index = scroll + i;
+            Chrome.drawRow(g, width, top + i * rowHeight,
+                names[index],
+                index < details.length ? details[index] : null,
+                index == selected);
+        }
+        g.setClip(0, 0, width, height);
+
+        // Say there is more, rather than letting the list end at the edge with
+        // no sign that it did not.
+        if (scroll + visible < names.length) {
+            g.setColor(Chrome.ACCENT);
+            g.fillTriangle(width - 12, bottom - 10, width - 4, bottom - 10, width - 8, bottom - 4);
+        }
+        if (scroll > 0) {
+            g.setColor(Chrome.ACCENT);
+            g.fillTriangle(width - 12, top + 10, width - 4, top + 10, width - 8, top + 4);
+        }
+    }
+
+    protected void keyPressed(int keyCode) {
+        move(keyCode);
+    }
+
+    protected void keyRepeated(int keyCode) {
+        move(keyCode);
+    }
+
+    private void move(int keyCode) {
+        int action = 0;
+        try {
+            action = getGameAction(keyCode);
+        } catch (IllegalArgumentException e) {
+            action = 0;
+        }
+
+        if (action == Canvas.UP) {
+            select(selected - 1);
+            return;
+        }
+        if (action == Canvas.DOWN) {
+            select(selected + 1);
+            return;
+        }
+        if (action == Canvas.FIRE || keyCode == 10 || keyCode == 13) {
+            if (selected >= 0 && selected < names.length) {
+                listener.selected(selected);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Draw the connection screens instead of leaving them to MIDP

The first thing anyone saw was a white List and a Form of plain text fields,
drawn by the device, sitting in front of a terminal that looked nothing like
them.

Not BlackBerry's own widgets, which has now been checked three times and is not
going to change: `net.rim.device.api.ui` is a protected API and using it would
need a signature from an authority that shut down. That constraint is the
reason this project exists.

Drawn, then. A Canvas gives every pixel, which is how the terminal screen
already works. Dark chrome, a title bar with an accent rule, rows carrying the
connection name over the account it reaches, a selection that looks selected,
a hint line at the foot, and arrows to say the list continues rather than
letting it stop at the edge with no sign that it had.

Text stays with MIDP's own Font rather than the terminal's bitmap atlas. The
atlas is monospace at eight pixels, which is right for a terminal grid and
wrong for a label.

Text *entry* stays with the platform entirely. A field opens `TextBox`, the
native full-screen editor, which already handles this keyboard, its input modes
and its capitalisation rules correctly. Reimplementing that on a canvas would
be worse in every way that matters, and the editor is the one place where being
worse would be felt on every keystroke.

The editor is the same drawn list, one row per field. Two of its rows are
choices rather than values and simply change when opened; the rest hand over to
TextBox. The password row shows "set" or "not set" and never the value, not
even as asterisks whose count would give away its length.

Every command stays in the menu on every screen, and Quit is on all three. The
drawing cannot be verified from here, and a screen that draws wrongly must
still be one the user can act on and leave — which is exactly the trap
full-screen mode set earlier, when the menu disappeared along with the way out.

Closes #46.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

