### PR TITLE
Reach a server through a WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ large here. An 8×14 cell gives the 60×25 terminal this screen should have.
 - [x] Runs on a Bold 9790: connects, authenticates, opens a shell
 - [x] Saved connections, host key confirmation, and a transport two threads can share
 - [x] Screens drawn rather than left to MIDP's own forms
+- [x] SSH over a WebSocket, for a network whose only entrance speaks HTTP
 - [ ] Keyboard mapping confirmed against the hardware's real key codes
 
 ## Prior art

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cd "$(dirname "$0")"
 
 NAME=berryssh
 VENDOR="berryssh"
-VERSION=0.5.0
+VERSION=0.6.0
 MIDLET_CLASS=berryssh.device.BerrysshMIDlet
 
 OUT=out

--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -8,6 +8,7 @@ import berryssh.protocol.Message;
 import berryssh.protocol.Negotiation;
 import berryssh.protocol.Transport;
 import berryssh.protocol.UserAuth;
+import berryssh.protocol.WebSocket;
 import berryssh.protocol.Utf8;
 import berryssh.terminal.VT320;
 
@@ -60,6 +61,7 @@ public class ServerTests {
         survivesTypingWhileOutputArrives();
         survivesARekey();
         authenticatesWithAKey();
+        reachesAServerThroughAWebSocket();
 
         System.out.println();
         System.out.println(passed + " passed, " + failed + " failed");
@@ -671,6 +673,70 @@ public class ServerTests {
             } finally {
                 second.close();
             }
+        } finally {
+            socket.close();
+        }
+    }
+
+    /**
+     * A full session carried inside a WebSocket.
+     *
+     * This is how the handset reaches a network whose only entrance speaks
+     * HTTP: it cannot run a VPN, and behind Cloudflare there is no raw TCP
+     * route to fall back on. The bridge on the far side turns the frames back
+     * into a socket.
+     *
+     * The bridge used here is written from RFC 6455 independently of the
+     * client, which is the point — a client tested against its own idea of the
+     * protocol proves nothing.
+     */
+    private static void reachesAServerThroughAWebSocket() throws Exception {
+        Socket socket;
+        try {
+            socket = new Socket(host, 8090);
+        } catch (IOException e) {
+            System.out.println("  SKIP  websocket: nothing on " + host + ":8090");
+            return;
+        }
+        try {
+            socket.setSoTimeout(20000);
+            EntropyPool random = new EntropyPool();
+            random.seed();
+
+            WebSocket ws = WebSocket.connect(socket.getInputStream(), socket.getOutputStream(),
+                host + ":8090", "/ssh", random);
+            checkTrue("the bridge upgrades the connection", ws != null);
+
+            // From here nothing knows it is not a socket, which is the whole
+            // reason Connection was built to take streams.
+            Connection connection = new Connection(ws.inputStream(), ws.outputStream(), random);
+            HostKey key = connection.handshake();
+            checkTrue("the key exchange completes through the WebSocket",
+                "SHA256:9tqjakW/Ia6U4hT3VgAv8EXXCxC1d3ez9mr5qjVTRZs".equals(key.fingerprint()));
+
+            UserAuth auth = new UserAuth(connection, user);
+            auth.begin();
+            auth.queryMethods();
+            checkTrue("authentication works through the WebSocket",
+                auth.password(password).succeeded());
+
+            Channel channel = Channel.openSession(connection);
+            channel.requestPty("xterm", 60, 25);
+            channel.requestShell();
+            channel.write(Utf8.encode("echo thro''ugh-the-tunnel; exit\n"));
+
+            StringBuffer output = new StringBuffer();
+            byte[] buffer = new byte[4096];
+            for (;;) {
+                int n = channel.read(buffer, 0, buffer.length);
+                if (n < 0) {
+                    break;
+                }
+                output.append(Utf8.decode(buffer, 0, n));
+            }
+            checkTrue("a shell runs through the WebSocket",
+                output.toString().indexOf("through-the-tunnel") >= 0);
+            channel.close();
         } finally {
             socket.close();
         }

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -25,6 +25,7 @@ import berryssh.protocol.KnownHosts;
 import berryssh.protocol.OpenSshKey;
 import berryssh.protocol.UserAuth;
 import berryssh.protocol.Utf8;
+import berryssh.protocol.WebSocket;
 import berryssh.terminal.BitmapFont;
 import berryssh.terminal.VT320;
 
@@ -82,7 +83,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
 
     private static final String[] FIELDS = {
         "Name", "Host", "Port", "User", "Password", "Save password",
-        "Private key", "Terminal size"
+        "Private key", "Terminal size", "WebSocket path"
     };
 
     private Display display;
@@ -99,6 +100,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
     private boolean editSavePassword;
     private String editKey = "";
     private int editFontSize;
+    private String editWsPath = "";
     private int editingField = -1;
 
     private TextBox entry;
@@ -332,6 +334,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         editSavePassword = profile != null && profile.savePassword();
         editKey = profile == null ? "" : profile.privateKey();
         editFontSize = profile == null ? 0 : profile.fontSize();
+        editWsPath = profile == null ? "" : profile.webSocketPath();
 
         if (editor == null) {
             editor = new ListScreen("Connection", new ListScreen.Listener() {
@@ -360,7 +363,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             editPassword.length() > 0 ? "set" : "not set",
             editSavePassword ? "yes  (stored unencrypted)" : "no",
             editKey.length() > 0 ? "set" : "not set  (paste id_ed25519)",
-            Profile.SIZE_LABELS[editFontSize]
+            Profile.SIZE_LABELS[editFontSize],
+            editWsPath.length() > 0 ? editWsPath : "not used  (plain socket)"
         };
         String[] names = new String[FIELDS.length];
         for (int i = 0; i < FIELDS.length; i++) {
@@ -404,6 +408,8 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             case 3: value = editUser; size = 32;
                     constraints = TextField.EMAILADDR | TextField.NON_PREDICTIVE; break;
             case 4: value = editPassword; size = 64; constraints = TextField.PASSWORD; break;
+            case 8: value = editWsPath; size = 128;
+                    constraints = TextField.URL | TextField.NON_PREDICTIVE; break;
             default: value = editKey; size = 2048; constraints = TextField.ANY; break;
         }
 
@@ -422,6 +428,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             case 2: editPort = value.trim(); break;
             case 3: editUser = value.trim(); break;
             case 4: editPassword = value; break;
+            case 8: editWsPath = value.trim(); break;
             default: editKey = value.trim(); break;
         }
         editingField = -1;
@@ -450,7 +457,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
         }
 
         Profile profile = new Profile(name, editHost, parsePort(editPort), editUser,
-            editPassword, editSavePassword, editKey, editFontSize);
+            editPassword, editSavePassword, editKey, editFontSize, editWsPath);
         try {
             // Renaming replaces rather than duplicating.
             if (editingName != null && !editingName.equals(name)) {
@@ -530,6 +537,18 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
             socket = openSocket(host, port);
             InputStream in = socket.openInputStream();
             OutputStream out = socket.openOutputStream();
+
+            // When a path is set the socket is only carrying HTTP, and what
+            // SSH actually runs on is the WebSocket inside it. Connection
+            // cannot tell the difference, which is the point of it taking
+            // streams rather than a socket.
+            if (profile.usesWebSocket()) {
+                canvas.setStatus("upgrading to a WebSocket...");
+                WebSocket ws = WebSocket.connect(in, out, host + ":" + port,
+                    profile.webSocketPath(), random);
+                in = ws.inputStream();
+                out = ws.outputStream();
+            }
 
             Connection connection = new Connection(in, out, random);
             HostKey key = connection.handshake();

--- a/ssh/src/berryssh/device/Profile.java
+++ b/ssh/src/berryssh/device/Profile.java
@@ -36,7 +36,8 @@ public final class Profile {
      * connection list that empties itself on upgrade is worse than the feature
      * is worth.
      */
-    private static final int FORMAT = 2;
+    private static final int FORMAT = 3;
+    private static final int FORMAT_WITHOUT_WEBSOCKET = 2;
     private static final int FORMAT_WITHOUT_KEY = 1;
 
     /** Cell sizes the atlases exist for, and what they give on a 480x360 screen. */
@@ -52,14 +53,21 @@ public final class Profile {
     private final boolean savePassword;
     private final String privateKey;
     private final int fontSize;
+    private final String webSocketPath;
 
     public Profile(String name, String host, int port, String user,
                    String password, boolean savePassword) {
-        this(name, host, port, user, password, savePassword, "", 0);
+        this(name, host, port, user, password, savePassword, "", 0, "");
     }
 
     public Profile(String name, String host, int port, String user, String password,
                    boolean savePassword, String privateKey, int fontSize) {
+        this(name, host, port, user, password, savePassword, privateKey, fontSize, "");
+    }
+
+    public Profile(String name, String host, int port, String user, String password,
+                   boolean savePassword, String privateKey, int fontSize,
+                   String webSocketPath) {
         this.name = name;
         this.host = host;
         this.port = port;
@@ -68,6 +76,7 @@ public final class Profile {
         this.savePassword = savePassword;
         this.privateKey = privateKey == null ? "" : privateKey;
         this.fontSize = (fontSize < 0 || fontSize >= CELL_WIDTHS.length) ? 0 : fontSize;
+        this.webSocketPath = webSocketPath == null ? "" : webSocketPath;
     }
 
     public String name() {
@@ -113,6 +122,20 @@ public final class Profile {
         return CELL_HEIGHTS[fontSize];
     }
 
+    /**
+     * The resource to upgrade to a WebSocket at, or empty for a plain socket.
+     *
+     * When it is set, host and port address the HTTP endpoint rather than the
+     * SSH server — the bridge on the far side decides what the frames reach.
+     */
+    public String webSocketPath() {
+        return webSocketPath;
+    }
+
+    public boolean usesWebSocket() {
+        return webSocketPath.length() > 0;
+    }
+
     public String fontResource() {
         return "/fonts/mono" + cellWidth() + "x" + cellHeight() + ".png";
     }
@@ -144,17 +167,19 @@ public final class Profile {
         w.writeString(Utf8.encode(savePassword ? password : ""));
         w.writeString(Utf8.encode(privateKey));
         w.writeUint32(fontSize);
+        w.writeString(Utf8.encode(webSocketPath));
         return w.toByteArray();
     }
 
     public static Profile decode(byte[] record) throws IOException {
         WireReader r = new WireReader(record);
         long format = r.readUint32();
-        if (format != FORMAT && format != FORMAT_WITHOUT_KEY) {
+        if (format != FORMAT && format != FORMAT_WITHOUT_WEBSOCKET
+                && format != FORMAT_WITHOUT_KEY) {
             // A record from a version that is not one of ours. Refusing it is
             // better than reading its fields in the wrong order.
             throw new SshException("saved connection is in format " + format
-                + ", not " + FORMAT_WITHOUT_KEY + " or " + FORMAT);
+                + ", not " + FORMAT_WITHOUT_KEY + " to " + FORMAT);
         }
         String name = Utf8.decode(r.readString());
         String host = Utf8.decode(r.readString());
@@ -165,11 +190,15 @@ public final class Profile {
 
         String privateKey = "";
         int fontSize = 0;
-        if (format == FORMAT) {
+        String webSocketPath = "";
+        if (format >= FORMAT_WITHOUT_WEBSOCKET) {
             privateKey = Utf8.decode(r.readString());
             fontSize = (int) r.readUint32();
         }
+        if (format >= FORMAT) {
+            webSocketPath = Utf8.decode(r.readString());
+        }
         return new Profile(name, host, port, user, password, savePassword,
-            privateKey, fontSize);
+            privateKey, fontSize, webSocketPath);
     }
 }

--- a/ssh/src/berryssh/protocol/WebSocket.java
+++ b/ssh/src/berryssh/protocol/WebSocket.java
@@ -1,0 +1,343 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import berryssh.crypto.EntropyPool;
+
+/**
+ * An RFC 6455 client, so SSH can cross a network whose only entrance speaks
+ * HTTP.
+ *
+ * The handset cannot run a VPN and there is no raw TCP route into the network
+ * behind Cloudflare — but a WebSocket is a TCP stream wearing an HTTP
+ * handshake, and a bridge on the far side turns it back into a socket. What
+ * comes out of here is an InputStream and an OutputStream, which is all
+ * {@link Connection} ever wanted, so nothing above this changes.
+ *
+ * <b>Plain ws://, deliberately.</b> The device cannot negotiate TLS 1.2, so the
+ * outer layer is unencrypted, and it costs nothing: SSH is already end to end
+ * encrypted and the relay carries ciphertext it cannot read. What makes an
+ * untrusted relay acceptable is the host key check, which is unaffected.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class WebSocket {
+
+    private static final int OPCODE_CONTINUATION = 0x0;
+    private static final int OPCODE_BINARY = 0x2;
+    private static final int OPCODE_CLOSE = 0x8;
+    private static final int OPCODE_PING = 0x9;
+    private static final int OPCODE_PONG = 0xa;
+
+    private static final int MASK_LENGTH = 4;
+
+    private final InputStream in;
+    private final OutputStream out;
+    private final EntropyPool random;
+
+    private final Input reader = new Input();
+    private final Output writer = new Output();
+
+    private byte[] pending = new byte[0];
+    private int pendingAt;
+    private boolean closed;
+
+    private WebSocket(InputStream in, OutputStream out, EntropyPool random) {
+        this.in = in;
+        this.out = out;
+        this.random = random;
+    }
+
+    /**
+     * Performs the upgrade over an already-open connection and returns the
+     * WebSocket carried on it.
+     *
+     * @param host the Host header, which a reverse proxy routes on
+     * @param path the resource, which the bridge maps to a destination
+     */
+    public static WebSocket connect(InputStream in, OutputStream out, String host,
+                                    String path, EntropyPool random) throws IOException {
+        WebSocket socket = new WebSocket(in, out, random);
+        socket.handshake(host, path);
+        return socket;
+    }
+
+    public InputStream inputStream() {
+        return reader;
+    }
+
+    public OutputStream outputStream() {
+        return writer;
+    }
+
+    private void handshake(String host, String path) throws IOException {
+        byte[] nonce = random.nextBytes(16);
+        StringBuffer request = new StringBuffer(256);
+        request.append("GET ").append(path).append(" HTTP/1.1\r\n");
+        request.append("Host: ").append(host).append("\r\n");
+        request.append("Upgrade: websocket\r\n");
+        request.append("Connection: Upgrade\r\n");
+        request.append("Sec-WebSocket-Key: ").append(Base64.encode(nonce)).append("\r\n");
+        request.append("Sec-WebSocket-Version: 13\r\n");
+        request.append("\r\n");
+        out.write(Ascii.toBytes(request.toString()));
+        out.flush();
+
+        String status = readLine();
+        // "HTTP/1.1 101 Switching Protocols". Anything else is a proxy telling
+        // us something, and its text is worth more than a generic failure.
+        if (status.indexOf(" 101") < 0) {
+            throw new SshException("the bridge refused the upgrade: " + status);
+        }
+
+        boolean upgraded = false;
+        for (;;) {
+            String header = readLine();
+            if (header.length() == 0) {
+                break;
+            }
+            // Compared by hand rather than with equalsIgnoreCase: the device's
+            // locale is Turkish, where case folding is lossy. Header names are
+            // ASCII, so a byte-wise fold over A-Z is both correct and total.
+            if (startsWithFolded(header, "upgrade:")
+                    && indexOfFolded(header, "websocket") >= 0) {
+                upgraded = true;
+            }
+        }
+        if (!upgraded) {
+            throw new SshException("the bridge answered 101 without upgrading");
+        }
+
+        // Sec-WebSocket-Accept is not checked. Verifying it needs SHA-1, which
+        // this project has no other use for, and it is not what protects this
+        // connection — it exists to stop a confused intermediary being talked
+        // into forwarding frames. The host key check is the real defence, and
+        // it is unaffected by anything a relay does.
+    }
+
+    /** Reads one CRLF-terminated header line, a byte at a time. */
+    private String readLine() throws IOException {
+        StringBuffer line = new StringBuffer(64);
+        for (;;) {
+            int c = in.read();
+            if (c < 0) {
+                throw new SshException("the bridge closed during the upgrade");
+            }
+            if (c == '\n') {
+                break;
+            }
+            if (c != '\r') {
+                line.append((char) c);
+            }
+            if (line.length() > 8192) {
+                throw new SshException("the bridge sent an implausible header");
+            }
+        }
+        return line.toString();
+    }
+
+    /** Sends one binary frame, masked as a client must. */
+    private synchronized void sendFrame(int opcode, byte[] data, int offset, int length)
+            throws IOException {
+        byte[] header = new byte[14];
+        int at = 0;
+        header[at++] = (byte) (0x80 | opcode);          // FIN, never fragmented
+
+        // The mask bit is not optional for a client. A server that receives an
+        // unmasked frame is required to fail the connection.
+        if (length < 126) {
+            header[at++] = (byte) (0x80 | length);
+        } else if (length < 65536) {
+            header[at++] = (byte) (0x80 | 126);
+            header[at++] = (byte) (length >>> 8);
+            header[at++] = (byte) length;
+        } else {
+            header[at++] = (byte) (0x80 | 127);
+            for (int i = 56; i >= 0; i -= 8) {
+                header[at++] = (byte) (((long) length) >>> i);
+            }
+        }
+
+        byte[] mask = random.nextBytes(MASK_LENGTH);
+        System.arraycopy(mask, 0, header, at, MASK_LENGTH);
+        at += MASK_LENGTH;
+
+        byte[] masked = new byte[length];
+        for (int i = 0; i < length; i++) {
+            masked[i] = (byte) (data[offset + i] ^ mask[i % MASK_LENGTH]);
+        }
+
+        out.write(header, 0, at);
+        out.write(masked, 0, length);
+        out.flush();
+    }
+
+    /**
+     * Reads frames until one carries data, answering the control frames rather
+     * than passing them up. A ping left unanswered is a connection an
+     * intermediary will eventually drop.
+     */
+    private void receive() throws IOException {
+        for (;;) {
+            int first = in.read();
+            if (first < 0) {
+                closed = true;
+                return;
+            }
+            int second = readByte();
+            int opcode = first & 0x0f;
+            boolean masked = (second & 0x80) != 0;
+
+            long length = second & 0x7f;
+            if (length == 126) {
+                length = (readByte() << 8) | readByte();
+            } else if (length == 127) {
+                length = 0;
+                for (int i = 0; i < 8; i++) {
+                    length = (length << 8) | readByte();
+                }
+            }
+            if (length > 1024L * 1024L) {
+                throw new SshException("the bridge sent a " + length + " byte frame");
+            }
+
+            byte[] mask = null;
+            if (masked) {
+                // A server should not mask, but unmasking correctly costs
+                // nothing and refusing would be a compatibility problem
+                // rather than a safety one.
+                mask = new byte[MASK_LENGTH];
+                readFully(mask, 0, MASK_LENGTH);
+            }
+
+            byte[] payload = new byte[(int) length];
+            readFully(payload, 0, payload.length);
+            if (mask != null) {
+                for (int i = 0; i < payload.length; i++) {
+                    payload[i] = (byte) (payload[i] ^ mask[i % MASK_LENGTH]);
+                }
+            }
+
+            if (opcode == OPCODE_CLOSE) {
+                closed = true;
+                return;
+            }
+            if (opcode == OPCODE_PING) {
+                sendFrame(OPCODE_PONG, payload, 0, payload.length);
+                continue;
+            }
+            if (opcode == OPCODE_PONG) {
+                continue;
+            }
+            if (opcode == OPCODE_BINARY || opcode == OPCODE_CONTINUATION) {
+                if (payload.length > 0) {
+                    append(payload);
+                    return;
+                }
+                continue;
+            }
+            throw new SshException("the bridge sent opcode " + opcode);
+        }
+    }
+
+    private void append(byte[] data) {
+        int left = pending.length - pendingAt;
+        byte[] combined = new byte[left + data.length];
+        System.arraycopy(pending, pendingAt, combined, 0, left);
+        System.arraycopy(data, 0, combined, left, data.length);
+        pending = combined;
+        pendingAt = 0;
+    }
+
+    private int readByte() throws IOException {
+        int c = in.read();
+        if (c < 0) {
+            throw new SshException("the bridge closed mid-frame");
+        }
+        return c;
+    }
+
+    private void readFully(byte[] b, int offset, int length) throws IOException {
+        while (length > 0) {
+            int n = in.read(b, offset, length);
+            if (n < 0) {
+                throw new SshException("the bridge closed mid-frame");
+            }
+            offset += n;
+            length -= n;
+        }
+    }
+
+    /** The bytes the far side sent, with the framing taken off. */
+    private final class Input extends InputStream {
+        public int read() throws IOException {
+            byte[] one = new byte[1];
+            int n = read(one, 0, 1);
+            return n < 0 ? -1 : (one[0] & 0xff);
+        }
+
+        public int read(byte[] b, int offset, int length) throws IOException {
+            while (pendingAt == pending.length) {
+                if (closed) {
+                    return -1;
+                }
+                receive();
+            }
+            int take = pending.length - pendingAt;
+            if (take > length) {
+                take = length;
+            }
+            System.arraycopy(pending, pendingAt, b, offset, take);
+            pendingAt += take;
+            return take;
+        }
+    }
+
+    /** Whatever is written becomes one binary frame. */
+    private final class Output extends OutputStream {
+        public void write(int b) throws IOException {
+            write(new byte[] { (byte) b }, 0, 1);
+        }
+
+        public void write(byte[] b, int offset, int length) throws IOException {
+            if (length > 0) {
+                sendFrame(OPCODE_BINARY, b, offset, length);
+            }
+        }
+    }
+
+    private static boolean startsWithFolded(String s, String lowerPrefix) {
+        if (s.length() < lowerPrefix.length()) {
+            return false;
+        }
+        for (int i = 0; i < lowerPrefix.length(); i++) {
+            if (fold(s.charAt(i)) != lowerPrefix.charAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int indexOfFolded(String s, String lower) {
+        for (int i = 0; i + lower.length() <= s.length(); i++) {
+            boolean hit = true;
+            for (int j = 0; j < lower.length(); j++) {
+                if (fold(s.charAt(i + j)) != lower.charAt(j)) {
+                    hit = false;
+                    break;
+                }
+            }
+            if (hit) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /** ASCII-only lower-casing, which String.toLowerCase is not on this device. */
+    private static char fold(char c) {
+        return (c >= 'A' && c <= 'Z') ? (char) (c + 32) : c;
+    }
+}

--- a/tools/wsbridge-install.md
+++ b/tools/wsbridge-install.md
@@ -1,0 +1,116 @@
+# Installing the WebSocket bridge
+
+The client half is done and tested. This is the server half, which touches a
+machine of yours and so is yours to run.
+
+## What it does, and what it exposes
+
+A path on an existing HTTP hostname becomes a way to reach one SSH server. The
+handset connects to `ws://<host>/<path>`, the bridge unwraps the frames and
+connects onward to the address that path is mapped to.
+
+**Read this part before running it.** A path that is reachable from the
+internet and lands on `sshd` is, in security terms, a port forward to that
+`sshd` — with three differences, all in its favour:
+
+- Only the addresses in `targets` can be dialled. Nothing else is reachable, no
+  matter what path is requested, so it is not an open proxy into the LAN.
+- No router port is opened. It rides the Cloudflare tunnel that is already
+  there, so it inherits whatever rate limiting and DDoS handling that has.
+- The bridge listens on loopback only. The reverse proxy in front is the only
+  thing that can reach it.
+
+What it does *not* do is add authentication of its own. The protection is
+`sshd`'s: those hosts take keys and not passwords. The bridge carries ciphertext
+it cannot read, and the client checks the host key, so a bridge that was
+tampered with or replaced would be refused at the far end rather than silently
+trusted.
+
+If that trade is not one you want, do not install it — the handset can still
+reach anything on the LAN when it is at home.
+
+## Install
+
+On the edge container (CT103), as root:
+
+```sh
+mkdir -p /opt/wsbridge
+curl -fsSL -o /opt/wsbridge/wsbridge.py \
+  https://raw.githubusercontent.com/cobanov/berryssh/main/tools/wsbridge.py
+```
+
+Write `/opt/wsbridge/config.json` with only the hosts you want reachable:
+
+```json
+{
+  "listen": 8022,
+  "bind": "127.0.0.1",
+  "targets": {
+    "/pve":   ["192.168.8.50", 22],
+    "/ct100": ["192.168.8.155", 22]
+  }
+}
+```
+
+Write `/etc/systemd/system/wsbridge.service`:
+
+```ini
+[Unit]
+Description=WebSocket to TCP bridge for berryssh
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/python3 /opt/wsbridge/wsbridge.py /opt/wsbridge/config.json
+Restart=always
+RestartSec=2
+DynamicUser=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+systemctl daemon-reload && systemctl enable --now wsbridge
+```
+
+Append to `/etc/caddy/Caddyfile` — Caddy passes WebSockets through
+`reverse_proxy` without any extra configuration:
+
+```
+ssh.cobanov.run:80 {
+	reverse_proxy 127.0.0.1:8022
+}
+```
+
+```sh
+systemctl reload caddy
+```
+
+`*.cobanov.run` already resolves through the tunnel, so no DNS step.
+
+## Check it
+
+From anywhere:
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+  -H 'Sec-WebSocket-Version: 13' \
+  http://ssh.cobanov.run/pve
+```
+
+`101` means the bridge answered. `404` means that path is not in `targets`,
+which is what a wrong or probing path should get.
+
+## On the handset
+
+In the connection editor set **Host** to `ssh.cobanov.run`, **Port** to `80`,
+and **WebSocket path** to `/pve`. Leave the path empty for an ordinary socket.
+
+Host and port then address the HTTP endpoint rather than the SSH server — which
+one is reached is decided by the path, on the bridge.

--- a/tools/wsbridge.py
+++ b/tools/wsbridge.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""A WebSocket-to-TCP bridge, so a client that can only speak HTTP can reach
+SSH.
+
+The handset cannot run a VPN, and behind Cloudflare there is no raw TCP route
+into the network to fall back on. HTTP is what the entrance speaks, and a
+WebSocket is a TCP stream wearing an HTTP handshake — so this unwraps it and
+connects onward.
+
+    wsbridge.py <config.json>
+
+    {
+      "listen": 8022,
+      "targets": {
+        "/pve":   ["192.168.8.50", 22],
+        "/ct100": ["192.168.8.155", 22]
+      }
+    }
+
+**The targets are an allowlist and that is the whole security model.** A bridge
+that connected wherever the path asked would be an open proxy into the network,
+reachable by anyone who found the hostname. Nothing outside this map is dialled.
+
+Beyond that the protection is SSH's own: the servers take keys, and the client
+checks the host key, so the bridge carries ciphertext it cannot read and cannot
+usefully tamper with — a forged or swapped host key is refused at the far end.
+
+Standard library only, so it runs anywhere Python does with nothing installed.
+"""
+import base64
+import hashlib
+import json
+import socket
+import struct
+import sys
+import threading
+
+GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+MAX_HEADERS = 65536
+MAX_FRAME = 1 << 20
+
+
+def read_request(conn):
+    data = b""
+    while b"\r\n\r\n" not in data:
+        chunk = conn.recv(4096)
+        if not chunk:
+            return None, None
+        data += chunk
+        if len(data) > MAX_HEADERS:
+            return None, None
+    head = data.decode("latin-1", "replace")
+    lines = head.split("\r\n")
+    path = lines[0].split(" ")[1] if len(lines[0].split(" ")) > 1 else ""
+    key = None
+    for line in lines[1:]:
+        if line.lower().startswith("sec-websocket-key:"):
+            key = line.split(":", 1)[1].strip()
+    return path, key
+
+
+def recv_exact(conn, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = conn.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("closed")
+        buf += chunk
+    return buf
+
+
+def read_frame(conn):
+    first, second = recv_exact(conn, 2)
+    opcode = first & 0x0F
+    masked = second & 0x80
+    length = second & 0x7F
+    if length == 126:
+        length = struct.unpack(">H", recv_exact(conn, 2))[0]
+    elif length == 127:
+        length = struct.unpack(">Q", recv_exact(conn, 8))[0]
+    if length > MAX_FRAME:
+        raise ConnectionError("frame too large")
+    mask = recv_exact(conn, 4) if masked else None
+    payload = recv_exact(conn, length) if length else b""
+    if mask:
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    return opcode, payload
+
+
+def write_frame(conn, opcode, payload):
+    header = bytes([0x80 | opcode])
+    n = len(payload)
+    if n < 126:
+        header += bytes([n])
+    elif n < 65536:
+        header += bytes([126]) + struct.pack(">H", n)
+    else:
+        header += bytes([127]) + struct.pack(">Q", n)
+    conn.sendall(header + payload)
+
+
+def serve(conn, targets):
+    upstream = None
+    try:
+        path, key = read_request(conn)
+        if not key:
+            conn.sendall(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            return
+        target = targets.get(path)
+        if target is None:
+            # Named rather than described: someone probing gets no map of what
+            # else might be here.
+            conn.sendall(b"HTTP/1.1 404 Not Found\r\n\r\n")
+            return
+
+        accept = base64.b64encode(
+            hashlib.sha1((key + GUID).encode()).digest()
+        ).decode()
+        conn.sendall(
+            (
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+            ).encode()
+        )
+
+        upstream = socket.create_connection((target[0], target[1]), timeout=15)
+        upstream.settimeout(None)
+
+        def pump_up():
+            try:
+                while True:
+                    opcode, payload = read_frame(conn)
+                    if opcode == 0x8:          # close
+                        break
+                    if opcode == 0x9:          # ping
+                        write_frame(conn, 0xA, payload)
+                        continue
+                    if opcode in (0x0, 0x1, 0x2) and payload:
+                        upstream.sendall(payload)
+            except Exception:
+                pass
+            finally:
+                try:
+                    upstream.shutdown(socket.SHUT_RDWR)
+                except Exception:
+                    pass
+
+        threading.Thread(target=pump_up, daemon=True).start()
+
+        while True:
+            data = upstream.recv(16384)
+            if not data:
+                break
+            write_frame(conn, 0x2, data)
+    except Exception:
+        pass
+    finally:
+        for s in (upstream, conn):
+            try:
+                if s:
+                    s.close()
+            except Exception:
+                pass
+
+
+def main():
+    config = json.load(open(sys.argv[1]))
+    targets = {k: (v[0], int(v[1])) for k, v in config["targets"].items()}
+    listen = int(config.get("listen", 8022))
+    # Bound to loopback: the only thing that should reach it is the reverse
+    # proxy in front, which is what terminates the public hostname.
+    server = socket.socket()
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((config.get("bind", "127.0.0.1"), listen))
+    server.listen(32)
+    print(f"wsbridge on {listen}, {len(targets)} target(s)", flush=True)
+    while True:
+        conn, _ = server.accept()
+        threading.Thread(target=serve, args=(conn, targets), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reach a server through a WebSocket

The handset cannot run Tailscale, and there is no raw TCP route to fall back
on: every record on the zone is proxied through Cloudflare, the wildcard points
at a tunnel, and nothing resolves to an origin. The single public entrance
speaks HTTP, and Cloudflare Tunnel carries TCP only with `cloudflared access
tcp` on the client — which this device will never run.

So the SSH stream goes inside a WebSocket, which is a TCP stream wearing an
HTTP handshake, and a bridge on the far side unwraps it.

This cost far less than it would have anywhere else, and for a reason worth
naming: `Connection` takes an InputStream and an OutputStream and has never
known where they came from. A WebSocket-backed pair substitutes with no change
above it at all. The same property is what made every protocol test above run
against a real server from the host.

**Plain ws://, deliberately.** The device cannot negotiate TLS 1.2, so the
outer layer is unencrypted, and it costs nothing: SSH is already end to end
encrypted and the relay carries ciphertext it cannot read. What makes an
untrusted relay acceptable is the host key check — a swapped or tampered bridge
is refused at the far end rather than silently trusted.

`Sec-WebSocket-Accept` is not verified. That needs SHA-1, which this project has
no other use for, and it is not what protects this connection: it exists to stop
a confused intermediary from being talked into forwarding frames. The status
line and the Upgrade header are checked instead, and the header comparison folds
case over A-Z by hand rather than calling toLowerCase, which is lossy under the
device's Turkish locale.

Verified by carrying a whole session — key exchange, authentication, a pty and
a shell — through a bridge written from RFC 6455 independently of the client. A
client tested against its own reading of a protocol proves nothing.

The bridge ships as tools/wsbridge.py, standard library only. Its target map is
an allowlist and that is deliberate: a bridge that dialled wherever the path
asked would be an open proxy into the network. Installing it touches a machine
that is not this project's to change, so tools/wsbridge-install.md sets out what
it exposes and leaves the decision where it belongs.

Closes #48.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

