### PR TITLE
Follow the wiki pages that were merged away

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ keyboard, and a real terminal on it.
 
 **[The wiki](https://github.com/cobanov/berryssh/wiki)** is the place to start
 if you want to use it rather than read it:
-[installing](https://github.com/cobanov/berryssh/wiki/Installing),
-[your first connection](https://github.com/cobanov/berryssh/wiki/Your-first-connection),
-[reaching servers that are not on your network](https://github.com/cobanov/berryssh/wiki/Reaching-remote-servers),
+[installing and connecting](https://github.com/cobanov/berryssh/wiki/Installing),
+[reaching servers outside your network](https://github.com/cobanov/berryssh/wiki/Remote-servers),
 and [troubleshooting](https://github.com/cobanov/berryssh/wiki/Troubleshooting)
 — which on this platform is mostly a list of failures that produce no error
 message.


### PR DESCRIPTION
Two of the four links pointed at pages that no longer exist: the first-connection page folded into Installing, and Reaching-remote-servers is now Remote-servers.