### PR TITLE
One byte comparison, and it is the careful one

### DIFF
--- a/spike2/src/CryptoTests.java
+++ b/spike2/src/CryptoTests.java
@@ -1,3 +1,4 @@
+import berryssh.crypto.Bytes;
 import berryssh.crypto.ChaCha20;
 import berryssh.crypto.EntropyPool;
 import berryssh.crypto.Hmac;
@@ -116,13 +117,18 @@ public class CryptoTests {
                     ascii("x")))));
 
         checkTrue("tags that match compare equal",
-            Hmac.equal(Hmac.compute(ascii("k"), ascii("m")),
+            Bytes.equal(Hmac.compute(ascii("k"), ascii("m")),
                 Hmac.compute(ascii("k"), ascii("m"))));
         checkTrue("a tag under a different key does not",
-            !Hmac.equal(Hmac.compute(ascii("k"), ascii("m")),
+            !Bytes.equal(Hmac.compute(ascii("k"), ascii("m")),
                 Hmac.compute(ascii("K"), ascii("m"))));
-        checkTrue("tags of different lengths do not",
-            !Hmac.equal(new byte[32], new byte[31]));
+        checkTrue("arrays of different lengths do not",
+            !Bytes.equal(new byte[32], new byte[31]));
+        checkTrue("a null is not equal to anything, including a null",
+            !Bytes.equal(null, new byte[0]) && !Bytes.equal(new byte[0], null)
+                && !Bytes.equal(null, null));
+        checkTrue("two empty arrays are equal",
+            Bytes.equal(new byte[0], new byte[0]));
     }
 
     private static byte[] repeat(byte value, int count) {

--- a/ssh/src/berryssh/crypto/Bytes.java
+++ b/ssh/src/berryssh/crypto/Bytes.java
@@ -1,0 +1,45 @@
+package berryssh.crypto;
+
+/**
+ * Comparing byte arrays, once, in the way that is safe for all of them.
+ *
+ * There were four of these: two that exited at the first difference and two
+ * that did not, and nothing at a call site to say which one it had reached
+ * for. That was survivable only because the early-exit pair happened to
+ * compare host keys, which are public — but the next thing that needs
+ * comparing might be an authentication tag or a derived key, and picking the
+ * wrong one of four would look exactly like picking the right one.
+ *
+ * So there is one, and it is the careful one. The cost is a few nanoseconds on
+ * comparisons that did not need the care.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+public final class Bytes {
+
+    private Bytes() {
+    }
+
+    /**
+     * Equality, without letting the time taken say where two arrays first
+     * differ.
+     *
+     * A comparison that stops at the first wrong byte tells an attacker how
+     * much of a forged tag was right, which is enough to build the rest of it
+     * one byte at a time.
+     *
+     * The length is not secret and is compared first: it is visible on the
+     * wire in every case this is used for, and two arrays of different lengths
+     * have nothing to compare byte by byte anyway.
+     */
+    public static boolean equal(byte[] a, byte[] b) {
+        if (a == null || b == null || a.length != b.length) {
+            return false;
+        }
+        int difference = 0;
+        for (int i = 0; i < a.length; i++) {
+            difference |= a[i] ^ b[i];
+        }
+        return difference == 0;
+    }
+}

--- a/ssh/src/berryssh/crypto/Hmac.java
+++ b/ssh/src/berryssh/crypto/Hmac.java
@@ -55,22 +55,9 @@ public final class Hmac {
         return hash.digest();
     }
 
-    /**
-     * Compares two tags without letting the time taken say where they differ.
-     *
-     * The client has no secret to leak by comparing carelessly — it is the
-     * bridge that must not turn a wrong key into a guessing game — but the
-     * routine belongs next to the primitive, and the client uses it too so
-     * there is only one comparison to get right.
-     */
-    public static boolean equal(byte[] a, byte[] b) {
-        if (a.length != b.length) {
-            return false;
-        }
-        int difference = 0;
-        for (int i = 0; i < a.length; i++) {
-            difference |= a[i] ^ b[i];
-        }
-        return difference == 0;
-    }
+    // A tag comparison used to live here, on the argument that it belonged
+    // next to the primitive. Nothing ever called it: the client proves a key
+    // by producing a tag, and it is the bridge — which is Python — that has to
+    // compare one. Bytes.equal is where the comparison the client does need
+    // lives now.
 }

--- a/ssh/src/berryssh/protocol/Connection.java
+++ b/ssh/src/berryssh/protocol/Connection.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import berryssh.crypto.Bytes;
 import berryssh.crypto.EntropyPool;
 
 /**
@@ -126,7 +127,7 @@ public final class Connection implements Transport.RekeyHandler {
             // The host key must still be the one already trusted. A server that
             // presents a different one mid-session is not the server we
             // authenticated to.
-            if (!sameBytes(hostKey.blob(), result.hostKey().blob())) {
+            if (!Bytes.equal(hostKey.blob(), result.hostKey().blob())) {
                 throw new SshException("the host key changed during a rekey");
             }
 
@@ -140,18 +141,6 @@ public final class Connection implements Transport.RekeyHandler {
             transport.decryptIncoming(new PacketCipher(
                 result.deriveKey('D', sessionId, PacketCipher.KEY_LENGTH)));
         }
-    }
-
-    private static boolean sameBytes(byte[] a, byte[] b) {
-        if (a == null || b == null || a.length != b.length) {
-            return false;
-        }
-        for (int i = 0; i < a.length; i++) {
-            if (a[i] != b[i]) {
-                return false;
-            }
-        }
-        return true;
     }
 
     /**

--- a/ssh/src/berryssh/protocol/KnownHosts.java
+++ b/ssh/src/berryssh/protocol/KnownHosts.java
@@ -2,6 +2,8 @@ package berryssh.protocol;
 
 import java.io.IOException;
 
+import berryssh.crypto.Bytes;
+
 /**
  * Whether the host key we were shown is the one we saw last time.
  *
@@ -44,7 +46,7 @@ public final class KnownHosts {
         if (known == null) {
             return UNKNOWN;
         }
-        return equalBytes(known, key.blob()) ? MATCHED : CHANGED;
+        return Bytes.equal(known, key.blob()) ? MATCHED : CHANGED;
     }
 
     /** Records a key the user accepted. */
@@ -81,15 +83,4 @@ public final class KnownHosts {
             + " genuinely rebuilt, remove the stored key and connect again.";
     }
 
-    private static boolean equalBytes(byte[] a, byte[] b) {
-        if (a.length != b.length) {
-            return false;
-        }
-        for (int i = 0; i < a.length; i++) {
-            if (a[i] != b[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
 }

--- a/ssh/src/berryssh/protocol/PacketCipher.java
+++ b/ssh/src/berryssh/protocol/PacketCipher.java
@@ -2,6 +2,7 @@ package berryssh.protocol;
 
 import java.io.IOException;
 
+import berryssh.crypto.Bytes;
 import berryssh.crypto.ChaCha20;
 import berryssh.crypto.Poly1305;
 
@@ -109,7 +110,7 @@ public final class PacketCipher {
         System.arraycopy(encryptedBody, 0, authenticated, LENGTH_FIELD_LENGTH, encryptedBody.length);
 
         byte[] expected = authenticate(nonce, authenticated, authenticated.length);
-        if (!equalsConstantTime(expected, tag)) {
+        if (!Bytes.equal(expected, tag)) {
             throw new SshException("packet authentication failed");
         }
 
@@ -129,6 +130,9 @@ public final class PacketCipher {
         return mac.finish();
     }
 
+    // The tag comparison lives in Bytes, with the other three that used to be
+    // scattered. See the note there on why there is only one of them.
+
     /**
      * The nonce is the sequence number, which is why a packet cannot be
      * replayed or reordered: its number is part of what authenticates it.
@@ -143,19 +147,4 @@ public final class PacketCipher {
         return nonce;
     }
 
-    /**
-     * Compared without an early exit. A comparison that stops at the first
-     * wrong byte tells an attacker how much of a forged tag was right, which is
-     * enough to build the rest of it a byte at a time.
-     */
-    private static boolean equalsConstantTime(byte[] a, byte[] b) {
-        if (a.length != b.length) {
-            return false;
-        }
-        int difference = 0;
-        for (int i = 0; i < a.length; i++) {
-            difference |= a[i] ^ b[i];
-        }
-        return difference == 0;
-    }
 }


### PR DESCRIPTION
Four implementations, two constant-time and two not, with nothing at a call site to say which. Not exploitable — the early-exit pair compared host keys, which are public — but the next thing needing comparison might be a tag or a derived key.

Now one, in `Bytes`, constant-time. `Hmac.equal` is deleted rather than moved: nothing called it.

Verified against a live OpenSSH, including the AEAD path.

Closes #54.