### PR TITLE
Show what the server said, and say something back on the way out

### DIFF
--- a/spike2/src/ServerTests.java
+++ b/spike2/src/ServerTests.java
@@ -62,6 +62,7 @@ public class ServerTests {
         survivesTypingWhileOutputArrives();
         survivesARekey();
         authenticatesWithAKey();
+        leavesPolitely();
         reachesAServerThroughAWebSocket();
         refusesAWrongBridgeKey();
 
@@ -750,6 +751,63 @@ public class ServerTests {
             checkTrue("a shell runs through the WebSocket",
                 output.toString().indexOf("through-the-tunnel") >= 0);
             channel.close();
+        } finally {
+            socket.close();
+        }
+    }
+
+    /**
+     * Leaving properly, RFC 4253 section 11.1.
+     *
+     * A malformed disconnect would not be obvious from our side — we close
+     * either way — so the check is that the server ends the stream without
+     * sending a DISCONNECT of its own. A server that objects to a packet says
+     * so before it goes, and that is the distinction being drawn.
+     *
+     * Messages already in flight are drained rather than treated as a reply.
+     * OpenSSH sends GLOBAL_REQUEST (hostkeys-00@openssh.com) the moment
+     * authentication succeeds, so it is on the wire before our disconnect
+     * arrives and says nothing about it. An earlier version of this test called
+     * that a failure, which made a correct disconnect look broken.
+     */
+    private static void leavesPolitely() throws Exception {
+        Socket socket = new Socket(host, port);
+        try {
+            socket.setSoTimeout(15000);
+            EntropyPool random = new EntropyPool();
+            random.seed();
+
+            Connection connection = new Connection(
+                socket.getInputStream(), socket.getOutputStream(), random);
+            connection.handshake();
+            UserAuth auth = new UserAuth(connection, user);
+            auth.begin();
+            auth.queryMethods();
+            checkTrue("authenticated before disconnecting",
+                auth.password(password).succeeded());
+
+            connection.transport().writeDisconnect(
+                Transport.DISCONNECT_BY_APPLICATION, "disconnected by the user");
+
+            String ending = null;
+            try {
+                // Bounded: a server that kept talking would be the failure, and
+                // this must not become the loop that finds out forever.
+                for (int i = 0; i < 8 && ending == null; i++) {
+                    connection.transport().readMessage();
+                }
+                ending = "the server was still sending after 8 messages";
+            } catch (IOException e) {
+                ending = e.getMessage() == null ? "" : e.getMessage();
+            }
+            // The stream must actually end. Accepting any IOException would let
+            // a disconnect that did nothing at all pass on the read timeout,
+            // which is the failure this test exists to catch. And "server
+            // disconnected" is what readMessage turns the server's own
+            // DISCONNECT into — the ending that means it objected.
+            checkTrue("the server accepts our disconnect and closes without complaint",
+                ending.indexOf("closed") >= 0
+                    && ending.indexOf("server disconnected") < 0);
         } finally {
             socket.close();
         }

--- a/ssh/src/berryssh/device/BerrysshMIDlet.java
+++ b/ssh/src/berryssh/device/BerrysshMIDlet.java
@@ -24,6 +24,7 @@ import berryssh.protocol.Connection;
 import berryssh.protocol.HostKey;
 import berryssh.protocol.KnownHosts;
 import berryssh.protocol.OpenSshKey;
+import berryssh.protocol.Transport;
 import berryssh.protocol.UserAuth;
 import berryssh.protocol.Utf8;
 import berryssh.protocol.WebSocket;
@@ -52,6 +53,13 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
      * cannot show what just scrolled past is barely a terminal on 24 rows.
      */
     private static final int SCROLLBACK_LINES = 500;
+
+    /**
+     * How long the goodbye packet gets. Long enough for a write into a socket
+     * buffer, short enough that nobody notices it when the connection is
+     * already dead.
+     */
+    private static final int GOODBYE_TIMEOUT_MS = 250;
 
     // The connection list
     private final Command connect = new Command("Connect", Command.ITEM, 1);
@@ -142,6 +150,13 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
 
     private SocketConnection socket;
     private Channel channel;
+
+    /**
+     * Kept so the session can be closed politely. Volatile because it is set on
+     * the session thread and read on the event thread, when Disconnect or Quit
+     * is chosen.
+     */
+    private volatile Connection connection;
     private volatile boolean running;
     private boolean fullScreenOn;
 
@@ -766,8 +781,9 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
                 }
             }
 
-            Connection connection = new Connection(in, out, random);
-            HostKey key = connection.handshake();
+            Connection open = new Connection(in, out, random);
+            connection = open;
+            HostKey key = open.handshake();
 
             // Not the host: through a bridge that is the relay, and every
             // machine behind one would share a record. See Profile.
@@ -795,7 +811,7 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
                 KnownHosts.accept(hostKeys, identity, port, key);
             }
 
-            UserAuth auth = new UserAuth(connection, profile.user());
+            UserAuth auth = new UserAuth(open, profile.user());
             auth.begin();
             auth.queryMethods();
 
@@ -817,7 +833,18 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
                 return;
             }
 
-            final Channel session = Channel.openSession(connection);
+            // A banner is where a server says the password expires next week,
+            // which environment you have landed on, or whatever notice it is
+            // obliged to show before a session opens. It was already being
+            // read and then dropped. Shown after authentication rather than as
+            // it arrives, so it does not interrupt a password prompt, and with
+            // the canvas as what follows so the session continues behind it.
+            String banner = auth.banner();
+            if (banner != null && banner.trim().length() > 0) {
+                show(banner.trim(), AlertType.INFO, canvas);
+            }
+
+            final Channel session = Channel.openSession(open);
             channel = session;
 
             // The canvas has to be on screen before its size means anything:
@@ -1002,7 +1029,60 @@ public final class BerrysshMIDlet extends MIDlet implements CommandListener {
 
     private void shutdown() {
         running = false;
+        sayGoodbye();
         closeQuietly();
+    }
+
+    /**
+     * Sends SSH_MSG_DISCONNECT before dropping the socket, RFC 4253 section
+     * 11.1. Without it the server cannot tell a user who chose to leave from a
+     * handset that fell off the network, and logs the second.
+     *
+     * On its own thread, with a bounded wait, because this runs on the event
+     * thread and neither half of the write is guaranteed to return. writePacket
+     * takes the send lock, which a rekey can be holding while blocked on a
+     * read, and the write itself goes to a socket that may already be gone.
+     * Waiting forever on a courtesy would trade a tidy server log for an
+     * application that cannot be closed.
+     *
+     * CLDC's Thread has join() but not join(long), so the bound comes from
+     * Object.wait — with a flag, because a thread that finishes before the wait
+     * begins would otherwise notify nobody and cost the full timeout.
+     */
+    private void sayGoodbye() {
+        final Connection open = connection;
+        connection = null;
+        if (open == null) {
+            return;
+        }
+
+        final boolean[] finished = new boolean[1];
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    open.transport().writeDisconnect(
+                        Transport.DISCONNECT_BY_APPLICATION, "disconnected by the user");
+                } catch (Exception e) {
+                    // Going anyway. A failure here means the connection was
+                    // already gone, which is the case this is trying to be
+                    // polite about — reporting it would be absurd.
+                }
+                synchronized (finished) {
+                    finished[0] = true;
+                    finished.notifyAll();
+                }
+            }
+        }).start();
+
+        synchronized (finished) {
+            if (!finished[0]) {
+                try {
+                    finished.wait(GOODBYE_TIMEOUT_MS);
+                } catch (InterruptedException e) {
+                    // Then we leave without it.
+                }
+            }
+        }
     }
 
     private void closeQuietly() {

--- a/ssh/src/berryssh/protocol/Transport.java
+++ b/ssh/src/berryssh/protocol/Transport.java
@@ -347,6 +347,13 @@ public final class Transport {
         }
     }
 
+    /**
+     * RFC 4253 section 11.1: the reason code for a client that is simply done.
+     * Not an error — a server logs this as an ordinary close rather than as a
+     * connection that broke.
+     */
+    public static final int DISCONNECT_BY_APPLICATION = 11;
+
     /** Tells the peer why we are going, then leaves. RFC 4253 section 11.1. */
     public void writeDisconnect(int reasonCode, String description) throws IOException {
         WireWriter w = new WireWriter(64 + description.length());


### PR DESCRIPTION
The banner was read and dropped — `UserAuth.banner()` had no caller. Now shown after authentication, with the canvas behind it.

Leaving dropped the socket; `writeDisconnect` was written and never called. Now sent, on its own thread with a bounded wait (CLDC has `join()` but not `join(long)`, so the bound is `Object.wait` plus a flag).

Verified against live OpenSSH. The first version of that test was wrong: it counted OpenSSH's post-auth GLOBAL_REQUEST as an objection. In-flight messages are drained now, and the test requires the stream to actually end — otherwise a no-op disconnect would pass on the read timeout. Confirmed by breaking it deliberately.

Closes #55. Closes #56.