### PR TITLE
One line reader, one fill, and less API than there were tests for

### DIFF
--- a/spike2/src/TransportTests.java
+++ b/spike2/src/TransportTests.java
@@ -105,10 +105,6 @@ public class TransportTests {
         check("uint32 at the top of its range", w.toByteArray(), "ffffffff");
 
         w = new WireWriter();
-        w.writeUint64(0x0102030405060708L);
-        check("uint64", w.toByteArray(), "0102030405060708");
-
-        w = new WireWriter();
         w.writeAsciiString("testing");
         check("string \"testing\"", w.toByteArray(), "0000000774657374696e67");
 
@@ -127,7 +123,6 @@ public class TransportTests {
         w.writeByte(0xfe);
         w.writeBoolean(true);
         w.writeUint32(0xdeadbeefL);
-        w.writeUint64(0xfedcba9876543210L);
         w.writeAsciiString("ssh-ed25519");
         w.writeString(hex("00112233"));
         w.writeMpint(hex("0080"));
@@ -138,7 +133,6 @@ public class TransportTests {
             checkTrue("round trip: byte", r.readByte() == 0xfe);
             checkTrue("round trip: boolean", r.readBoolean());
             checkTrue("round trip: uint32 past the sign bit", r.readUint32() == 0xdeadbeefL);
-            checkTrue("round trip: uint64 past the sign bit", r.readUint64() == 0xfedcba9876543210L);
             checkTrue("round trip: ascii string", "ssh-ed25519".equals(r.readAsciiString()));
             check("round trip: string", r.readString(), "00112233");
             check("round trip: mpint drops the sign byte", r.readMpint(), "80");
@@ -770,9 +764,24 @@ public class TransportTests {
      * The store itself is RMS and only exists on the device, so what is worth
      * testing here is what goes into a record and what comes back out.
      */
+    /**
+     * A connection with no key, no bridge and the default font.
+     *
+     * The shortening lives here rather than as a constructor on Profile, which
+     * is where it used to be. There it was reachable from the application, and
+     * being reachable it got used — the password prompt rebuilt a profile
+     * through one of these and silently dropped the WebSocket path. A test
+     * helper cannot cause that, because nothing but the tests can call it.
+     */
+    private static Profile basic(String name, String host, int port, String user,
+                                 String password, boolean savePassword) {
+        return new Profile(name, host, port, user, password, savePassword,
+            "", 0, "", "", "");
+    }
+
     private static void savedConnections() {
         try {
-            Profile full = new Profile("work", "example.org", 2222, "cobanov", "sifre", true);
+            Profile full = basic("work", "example.org", 2222, "cobanov", "sifre", true);
             Profile back = Profile.decode(full.encode());
             checkTrue("a saved connection round trips",
                 "work".equals(back.name())
@@ -784,7 +793,7 @@ public class TransportTests {
 
             // The password is left out of the record rather than written and
             // hidden behind a flag: a flag protects nobody who reads the record.
-            Profile unsaved = new Profile("home", "example.org", 22, "bb", "secret", false);
+            Profile unsaved = basic("home", "example.org", 22, "bb", "secret", false);
             Profile storedUnsaved = Profile.decode(unsaved.encode());
             checkTrue("a password that was not to be saved is not in the record",
                 storedUnsaved.password().length() == 0 && !storedUnsaved.savePassword());
@@ -793,7 +802,7 @@ public class TransportTests {
 
             // UTF-8 throughout: the device's default encoding would mangle both
             // of these, and neither is hypothetical for this user.
-            Profile turkish = new Profile("işyeri", "sunucu.example.org", 22,
+            Profile turkish = basic("işyeri", "sunucu.example.org", 22,
                 "çağrı", "parolağı", true);
             Profile turkishBack = Profile.decode(turkish.encode());
             checkTrue("Turkish characters survive a save and a load",
@@ -804,7 +813,7 @@ public class TransportTests {
             checkTrue("the list label identifies the server",
                 full.label().indexOf("cobanov@example.org:2222") >= 0);
             checkTrue("the default port is left out of the label",
-                new Profile("", "example.org", 22, "bb", "", false)
+                basic("", "example.org", 22, "bb", "", false)
                     .label().indexOf(":22") < 0);
 
             Profile bridged = new Profile("pve", "ssh.example.org", 80, "root", "",

--- a/ssh/src/berryssh/device/Profile.java
+++ b/ssh/src/berryssh/device/Profile.java
@@ -58,23 +58,16 @@ public final class Profile {
     private final String bridgeKey;
     private final String bridgeTarget;
 
-    public Profile(String name, String host, int port, String user,
-                   String password, boolean savePassword) {
-        this(name, host, port, user, password, savePassword, "", 0, "");
-    }
-
-    public Profile(String name, String host, int port, String user, String password,
-                   boolean savePassword, String privateKey, int fontSize) {
-        this(name, host, port, user, password, savePassword, privateKey, fontSize, "");
-    }
-
-    public Profile(String name, String host, int port, String user, String password,
-                   boolean savePassword, String privateKey, int fontSize,
-                   String webSocketPath) {
-        this(name, host, port, user, password, savePassword, privateKey, fontSize,
-            webSocketPath, "", "");
-    }
-
+    /**
+     * There were three shorter constructors above this one. Only the tests
+     * reached them in the end, which meant the tests were exercising a shape
+     * the application never builds — and one of them had already caused a bug,
+     * when the password prompt used the eight-argument form and silently
+     * dropped the WebSocket path.
+     *
+     * A connection has these fields. Passing all of them is not a burden worth
+     * a convenience that can lose one.
+     */
     public Profile(String name, String host, int port, String user, String password,
                    boolean savePassword, String privateKey, int fontSize,
                    String webSocketPath, String bridgeKey, String bridgeTarget) {

--- a/ssh/src/berryssh/device/RecordStoreProfiles.java
+++ b/ssh/src/berryssh/device/RecordStoreProfiles.java
@@ -34,13 +34,21 @@ public final class RecordStoreProfiles implements Profile.Store {
             int n = 0;
             while (records.hasNextElement()) {
                 byte[] record = records.nextRecord();
+                Profile profile;
                 try {
-                    found[n++] = Profile.decode(record);
+                    profile = Profile.decode(record);
                 } catch (IOException e) {
                     // A record this version cannot read is skipped rather than
                     // fatal: one unreadable entry should not cost the others.
-                    n--;
+                    continue;
                 }
+                // Decoded first, then stored. This used to be
+                // `found[n++] = Profile.decode(record)` with an `n--` in the
+                // catch, which was correct — Java evaluates the array index
+                // before the right-hand side, so a throw left n already
+                // incremented and the decrement put it back — but reading it
+                // required knowing that rule to see it was not an off-by-one.
+                found[n++] = profile;
             }
             Profile[] exact = new Profile[n];
             System.arraycopy(found, 0, exact, 0, n);

--- a/ssh/src/berryssh/protocol/BridgeAuth.java
+++ b/ssh/src/berryssh/protocol/BridgeAuth.java
@@ -158,31 +158,13 @@ public final class BridgeAuth {
     }
 
     /**
-     * Reads one line, a byte at a time.
-     *
-     * Deliberately unbuffered: after READY the very next byte belongs to SSH,
-     * and a reader that had pulled ahead would have eaten the start of the
-     * server's version string.
+     * Reads one line. Unbuffered, and it matters here more than anywhere: after
+     * READY the very next byte belongs to SSH, and a reader that had pulled
+     * ahead would have eaten the start of the server's version string. See
+     * {@link Lines}.
      */
     private static String readLine(InputStream in) throws IOException {
-        StringBuffer line = new StringBuffer(64);
-        for (;;) {
-            int c = in.read();
-            if (c < 0) {
-                throw new SshException(line.length() == 0
-                    ? "the bridge closed without answering"
-                    : "the bridge closed mid-line");
-            }
-            if (c == '\n') {
-                return line.toString();
-            }
-            if (c != '\r') {
-                line.append((char) c);
-            }
-            if (line.length() > MAX_LINE) {
-                throw new SshException("the bridge sent an implausible line");
-            }
-        }
+        return Lines.read(in, MAX_LINE, "bridge");
     }
 
     private static void writeLine(OutputStream out, String line) throws IOException {

--- a/ssh/src/berryssh/protocol/Lines.java
+++ b/ssh/src/berryssh/protocol/Lines.java
@@ -1,0 +1,72 @@
+package berryssh.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Reading a line, and filling a buffer, from a stream that must not be read
+ * ahead of.
+ *
+ * <b>The unbuffered part is the whole point, and it is why these are here
+ * rather than replaced by something from the library.</b> In all three places
+ * that read a line — the SSH version exchange, the WebSocket upgrade, and the
+ * bridge handshake — the very next byte after the line belongs to a different
+ * layer. A reader that pulled ahead in blocks would swallow the start of it,
+ * and CLDC 1.1 has no {@code BufferedInputStream} to push the excess back
+ * into. So every one of them reads a byte at a time, and that constraint is
+ * stated once here instead of being rediscovered three times.
+ *
+ * There were three copies of the line reader and two of the fill, differing
+ * only in their limits and the wording of their errors. Both of those are
+ * parameters.
+ *
+ * Written for -source 1.3: no generics, no enhanced for, no StringBuilder.
+ */
+final class Lines {
+
+    private Lines() {
+    }
+
+    /**
+     * Reads up to a newline, dropping a trailing carriage return.
+     *
+     * @param max  the most that will be kept before the peer is treated as
+     *             hostile rather than merely verbose
+     * @param what what to call the far side in an error, so the message says
+     *             which layer gave up
+     */
+    static String read(InputStream in, int max, String what) throws IOException {
+        StringBuffer line = new StringBuffer(64);
+        for (;;) {
+            int c = in.read();
+            if (c < 0) {
+                throw new SshException(line.length() == 0
+                    ? "the " + what + " closed without answering"
+                    : "the " + what + " closed mid-line");
+            }
+            if (c == '\n') {
+                return line.toString();
+            }
+            if (c != '\r') {
+                line.append((char) c);
+            }
+            if (line.length() > max) {
+                throw new SshException("the " + what + " sent a line longer than "
+                    + max + " bytes");
+            }
+        }
+    }
+
+    /** Reads exactly {@code length} bytes, or fails saying who stopped. */
+    static void readFully(InputStream in, byte[] b, int offset, int length, String what)
+            throws IOException {
+        while (length > 0) {
+            int n = in.read(b, offset, length);
+            if (n < 0) {
+                throw new SshException("the " + what + " closed mid-packet");
+            }
+            offset += n;
+            length -= n;
+        }
+    }
+}

--- a/ssh/src/berryssh/protocol/Transport.java
+++ b/ssh/src/berryssh/protocol/Transport.java
@@ -377,44 +377,17 @@ public final class Transport {
     }
 
     /**
-     * Reads one CR-LF-terminated line, a byte at a time.
-     *
-     * Reading ahead in blocks would swallow the first packet, and CLDC has no
-     * BufferedInputStream to push the excess back into. The 255-byte cap counts
-     * only what is kept, which is marginally more tolerant than the RFC — worth
-     * it to not reject a server over its line ending.
+     * Reads one CR-LF-terminated line. The 255-byte cap counts only what is
+     * kept, which is marginally more tolerant than the RFC — worth it to not
+     * reject a server over its line ending. See {@link Lines} for why it is a
+     * byte at a time.
      */
     private String readLine() throws IOException {
-        byte[] line = new byte[MAX_VERSION_LINE];
-        int n = 0;
-        for (;;) {
-            int c = in.read();
-            if (c < 0) {
-                throw new SshException("connection closed during the version exchange");
-            }
-            if (c == '\n') {
-                break;
-            }
-            if (n == line.length) {
-                throw new SshException("version line longer than " + MAX_VERSION_LINE + " bytes");
-            }
-            line[n++] = (byte) c;
-        }
-        if (n > 0 && line[n - 1] == '\r') {
-            n--;
-        }
-        return Ascii.fromBytes(line, 0, n);
+        return Lines.read(in, MAX_VERSION_LINE, "server");
     }
 
     private void readFully(byte[] b, int offset, int length) throws IOException {
-        while (length > 0) {
-            int n = in.read(b, offset, length);
-            if (n < 0) {
-                throw new SshException("connection closed mid-packet");
-            }
-            offset += n;
-            length -= n;
-        }
+        Lines.readFully(in, b, offset, length, "connection");
     }
 
     /** CLDC's Random has no nextBytes, so the words are unpacked by hand. */

--- a/ssh/src/berryssh/protocol/WebSocket.java
+++ b/ssh/src/berryssh/protocol/WebSocket.java
@@ -117,25 +117,12 @@ public final class WebSocket {
         // it is unaffected by anything a relay does.
     }
 
-    /** Reads one CRLF-terminated header line, a byte at a time. */
+    /** The most a header line may be before the far side is not a bridge. */
+    private static final int MAX_HEADER = 8192;
+
+    /** See {@link Lines} for why this cannot read ahead. */
     private String readLine() throws IOException {
-        StringBuffer line = new StringBuffer(64);
-        for (;;) {
-            int c = in.read();
-            if (c < 0) {
-                throw new SshException("the bridge closed during the upgrade");
-            }
-            if (c == '\n') {
-                break;
-            }
-            if (c != '\r') {
-                line.append((char) c);
-            }
-            if (line.length() > 8192) {
-                throw new SshException("the bridge sent an implausible header");
-            }
-        }
-        return line.toString();
+        return Lines.read(in, MAX_HEADER, "bridge");
     }
 
     /** Sends one binary frame, masked as a client must. */
@@ -260,14 +247,7 @@ public final class WebSocket {
     }
 
     private void readFully(byte[] b, int offset, int length) throws IOException {
-        while (length > 0) {
-            int n = in.read(b, offset, length);
-            if (n < 0) {
-                throw new SshException("the bridge closed mid-frame");
-            }
-            offset += n;
-            length -= n;
-        }
+        Lines.readFully(in, b, offset, length, "bridge");
     }
 
     /** The bytes the far side sent, with the framing taken off. */

--- a/ssh/src/berryssh/protocol/WireReader.java
+++ b/ssh/src/berryssh/protocol/WireReader.java
@@ -51,14 +51,10 @@ public final class WireReader {
              | (long) (buf[pos++] & 0xff);
     }
 
-    public long readUint64() throws IOException {
-        need(8);
-        long v = 0;
-        for (int i = 0; i < 8; i++) {
-            v = (v << 8) | (buf[pos++] & 0xff);
-        }
-        return v;
-    }
+    // There was a readUint64 here. No message this client handles carries one,
+    // so the only thing that ever called it was its own test — which made it
+    // look like a need rather than a completeness exercise. RFC 4251 still
+    // defines the type; if something ever needs it, it is eight lines.
 
     /** Reads bytes with no length prefix. */
     public byte[] readRaw(int length) throws IOException {

--- a/ssh/src/berryssh/protocol/WireWriter.java
+++ b/ssh/src/berryssh/protocol/WireWriter.java
@@ -53,12 +53,10 @@ public final class WireWriter {
         buf[pos++] = (byte) v;
     }
 
-    public void writeUint64(long v) {
-        ensure(8);
-        for (int shift = 56; shift >= 0; shift -= 8) {
-            buf[pos++] = (byte) (v >>> shift);
-        }
-    }
+    // writeUint64 went with the matching reader. RFC 4251 defines the type and
+    // nothing this client sends or receives uses it, so the pair existed to
+    // make the wire-type set look complete and were exercised only by the test
+    // that proved they were symmetrical with each other.
 
     /** Appends bytes with no length prefix. */
     public void writeRaw(byte[] b) {


### PR DESCRIPTION
Three copies of the same byte-at-a-time line reader and two of the fill, collapsed into `Lines`. The reason they cannot read ahead — the next byte belongs to another layer, and CLDC has no `BufferedInputStream` — is now stated once instead of three times.

`readUint64`/`writeUint64` removed: nothing sends or receives one.

`Profile`'s three shorter constructors removed. Not hypothetical — the password prompt used the 8-argument form and silently dropped the WebSocket path. The tests keep the shortening as a local helper the application cannot reach.

`RecordStoreProfiles.list` decodes before assigning; the old form was correct but required a JLS evaluation-order rule to read as such.

Closes #58.